### PR TITLE
Pass cors option to pact-node

### DIFF
--- a/src/pact.js
+++ b/src/pact.js
@@ -51,6 +51,7 @@ module.exports = (opts) => {
   const log = opts.log || path.resolve(process.cwd(), 'logs', 'pact.log')
   const logLevel = opts.logLevel || 'INFO'
   const spec = opts.spec || 2
+  const cors = opts.cors || false
   const server = serviceFactory.createServer({
     port: port,
     log: log,
@@ -58,7 +59,8 @@ module.exports = (opts) => {
     spec: spec,
     ssl: ssl,
     sslcert: sslcert,
-    sslkey: sslkey
+    sslkey: sslkey,
+    cors: cors
   })
   serviceFactory.logLevel(logLevel)
 

--- a/src/pact.js
+++ b/src/pact.js
@@ -27,6 +27,7 @@ const path = require('path')
  * @param {number} opts.port - port of the mock service, defaults to 1234
  * @param {string} opts.host - host address of the mock service, defaults to 127.0.0.1
  * @param {boolean} opts.ssl - SSL flag to identify the protocol to be used (default false, HTTP)
+ * @param {boolean} opts.cors - allow CORS OPTION requests to be accepted, defaults to false
  * @return {@link PactProvider}
  * @static
  */


### PR DESCRIPTION
This fixes a regression in pact 2.x where the pact-node CORS option was no longer exposed