### PR TITLE
Fixes 'provider.verify()' call in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ describe('Pact', () => {
 
       // (5) validate the interactions occurred, this will throw an error if it fails telling you what went wrong
       it('creates a contract between the TodoApp and TodoService', () => {
-        return pact.verify()
+        return provider.verify()
       })
     })
   });


### PR DESCRIPTION
I think this is correct, it matches all the examples in the ./examples folder of this repository