### PR TITLE
feat(port-check): check if port is available during setup() #37

### DIFF
--- a/config/webpack.web.config.js
+++ b/config/webpack.web.config.js
@@ -16,6 +16,9 @@ module.exports = {
   },
   target: 'web',
   externals: [ 'mitm' ],
+  node: {
+    net: 'empty'
+  },
   module: {
     loaders: [
       {

--- a/examples/e2e/test/consumer.spec.js
+++ b/examples/e2e/test/consumer.spec.js
@@ -136,8 +136,8 @@ describe('Pact', () => {
           }
         })
       })
-      .catch(e =>{
-        console.log('ERROR: ', e)
+      .catch(e => {
+        throw new Error("Unable to start the Pact Server: " + e)
       })
   })
 

--- a/src/common/net.js
+++ b/src/common/net.js
@@ -1,0 +1,17 @@
+/**
+ * Network module.
+ * @module net
+ * @private
+ */
+
+'use strict'
+const net = require('net')
+
+module.exports = {
+  isPortAvailable: (port, host) => new Promise((resolve, reject) => {
+    const server = net.createServer()
+      .listen({port: port, host: host, exclusive: true})
+      .on('error', err => (err.code === 'EADDRINUSE' ? reject(new Error(`Port ${port} is unavailable`)) : reject(err)))
+      .on('listening', () => server.once('close', () => resolve()).close())
+  })
+}

--- a/src/pact.js
+++ b/src/pact.js
@@ -9,6 +9,7 @@ require('es6-promise').polyfill()
 
 const isNil = require('lodash.isnil')
 const logger = require('./common/logger')
+const net = require('./common/net')
 const Matchers = require('./dsl/matchers')
 const Verifier = require('./dsl/verifier')
 const MockService = require('./dsl/mockService')
@@ -53,6 +54,7 @@ module.exports = (opts) => {
   const logLevel = opts.logLevel || 'INFO'
   const spec = opts.spec || 2
   const cors = opts.cors || false
+
   const server = serviceFactory.createServer({
     port: port,
     log: log,
@@ -76,7 +78,7 @@ module.exports = (opts) => {
      * Start the Mock Server.
      * @returns {Promise}
      */
-    setup: () => server.start(),
+    setup: () => net.isPortAvailable(port, host).then(() => server.start()),
 
     /**
      * Add an interaction to the {@link MockService}.

--- a/test/common/net.spec.js
+++ b/test/common/net.spec.js
@@ -1,0 +1,50 @@
+const sinon = require('sinon')
+const logger = require('../../src/common/logger')
+const net = require('../../src/common/net')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const expect = chai.expect
+
+chai.use(chaiAsPromised)
+var port = 1234
+
+describe('Net#isPortAvailable', () => {
+  context('when the port is not allowed to be bound', () => {
+    it('should return a rejected promise', () => {
+      expect(net.isPortAvailable(80, '0.0.0.0')).to.eventually.be.rejected
+    })
+  })
+
+  context('when the port is available', () => {
+    it('should return a fulfilled promise', () => {
+      expect(net.isPortAvailable(port, '0.0.0.0')).to.eventually.be.fulfilled
+    })
+  })
+
+  context('when the port is unavailable', () => {
+    it('should return a rejected promise', (done) => {
+      createServer(port).then((server) => {
+        net.isPortAvailable(port, '0.0.0.0')
+          .then(() => {
+            server.close()
+            done(new Error(`Port ${port} should not be available`))
+          }, e => {
+            done()
+          })
+      })
+    })
+  })
+})
+
+// Utility function to create a server on a given port and return a Promise
+const createServer = (port) => new Promise((resolve, reject) => {
+  const net = require('net')
+  const server = net.createServer()
+
+  server.on('error', (err) => reject(err))
+  server.on('listening', () => resolve(server))
+
+  server.listen(port, () => {
+    logger.info(`test server is up on port ${port}`);
+  })
+})


### PR DESCRIPTION
Fast fail a build during `setup()` if the port is taken by another process.

Results in a test failure similar to the below in the E2E [Mocha](https://github.com/pact-foundation/pact-js/blob/feat/port-check/examples/e2e/test/consumer.spec.js) test:

```shell
> e2e@1.0.0 test:consumer /Users/mfellows/development/public/pact-js/examples/e2e
> mocha test/consumer.spec.js

  Pact
    1) "before all" hook
    2) "after all" hook


  0 passing (35ms)
  2 failing

  1) Pact "before all" hook:
     Error: Unable to start the Pact Server: Error: Port 1234 is unavailable
      at provider.setup.then.then.then.catch.e (test/consumer.spec.js:140:15)
      at process._tickCallback (internal/process/next_tick.js:103:7)
```


Fixes #37 