### PR TITLE
feat(verifications): update example to publish verification results

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,15 @@ Once you have created Pacts for your Consumer, you need to validate those Pacts 
 ```js
 const verifier = require('pact').Verifier;
 let opts = {
-	providerBaseUrl: <String>,       // Running API provider host endpoint. Required.
-	pactUrls: <Array>,               // Array of local Pact file paths or Pact Broker URLs (http based). Required.
-	providerStatesUrl: <String>,     // URL to fetch the provider states for the given provider API. Optional.
-	providerStatesSetupUrl <String>, // URL to send PUT requests to setup a given provider state. Optional.
-	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
-	pactBrokerPassword: <String>,    // Password for Pact Broker basic authentication. Optional
-  timeout: <Number>                // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
+	providerBaseUrl: <String>,           // Running API provider host endpoint. Required.
+	pactUrls: <Array>,                   // Array of local Pact file paths or Pact Broker URLs (http based). Required.
+	providerStatesUrl: <String>,         // URL to fetch the provider states for the given provider API. Optional.
+	providerStatesSetupUrl <String>,     // URL to send PUT requests to setup a given provider state. Optional.
+	pactBrokerUsername: <String>,        // Username for Pact Broker basic authentication. Optional
+	pactBrokerPassword: <String>,        // Password for Pact Broker basic authentication. Optional
+  publishVerificationResult: <Boolean> // Publish verification result to Broker. Optional
+	providerVersion: <Boolean>           // Provider version, required to publish verification result to Broker. Optional otherwise.
+  timeout: <Number>                    // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
 };
 
 verifier.verifyProvider(opts)).then(function () {

--- a/examples/e2e/test/provider.spec.js
+++ b/examples/e2e/test/provider.spec.js
@@ -38,7 +38,7 @@ server.listen(8081, () => {
 
 // Verify that the provider meets all consumer expectations
 describe('Pact Verification', () => {
-  it('should validate the expectations of Matching Service', function() { // lexical binding required here
+  it('should validate the expectations of Matching Service', function () { // lexical binding required here
     this.timeout(10000)
 
     let opts = {
@@ -46,11 +46,13 @@ describe('Pact Verification', () => {
       providerStatesUrl: 'http://localhost:8081/states',
       providerStatesSetupUrl: 'http://localhost:8081/setup',
       // Remote pacts
-      // pactUrls: ['https://test.pact.dius.com.au/pacts/provider/Animal%20Profile%20Service/consumer/Matching%20Service/latest'],
+      pactUrls: ['https://test.pact.dius.com.au/pacts/provider/Animal%20Profile%20Service/consumer/Matching%20Service/latest'],
       // Local pacts
-      pactUrls: [path.resolve(process.cwd(), './pacts/matching_service-animal_profile_service.json')],
+      // pactUrls: [path.resolve(process.cwd(), './pacts/matching_service-animal_profile_service.json')],
       pactBrokerUsername: 'dXfltyFMgNOFZAxr8io9wJ37iUpY42M',
-      pactBrokerPassword: 'O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1'
+      pactBrokerPassword: 'O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1',
+      publishVerificationResult: true,
+      providerVersion: "1.0.0"
     }
 
     return verifier.verifyProvider(opts)


### PR DESCRIPTION
Adds support for a new feature of the broker - the ability to send provider verification results back to the Broker, allowing more intelligent CI practices.

The main use case this solves is allowing you (probably via a CI / CD processe) to detect Consumer changes that have not yet been verified by a provider. Publishing the status to the broker allows tooling to then query this status, and block a deployment if the contract has changed or has not been verified since last published.

See https://github.com/realestate-com-au/pact/blob/master/CHANGELOG.md#1110-8-may-2017 for background.

Waiting for https://github.com/pact-foundation/pact-node/pull/35 before merging.