### PR TITLE
feat(mock service): add pactfile_write_mode option handling

### DIFF
--- a/src/dsl/mockService.d.ts
+++ b/src/dsl/mockService.d.ts
@@ -1,7 +1,16 @@
 import {Interaction} from './interaction';
 
+export type PactfileWriteMode = "overwrite" | "update" | "smart" | "none";
+
 export class MockService {
-  constructor (consumer: string, provider: string, port?: number, host?: string, ssl?: boolean);
+  constructor (
+    consumer: string,
+    provider: string,
+    port?: number,
+    host?: string,
+    ssl?: boolean,
+    pactfileWriteMode?: PactfileWriteMode,
+  );
   addInteraction(interaction: Interaction): Promise<string>;
   removeInteractions(): Promise<string>;
   verify(): Promise<string>;

--- a/src/dsl/mockService.js
+++ b/src/dsl/mockService.js
@@ -18,8 +18,9 @@ module.exports = class MockService {
    * @param {number} port - the mock service port, defaults to 1234
    * @param {string} host - the mock service host, defaults to 127.0.0.1
    * @param {boolean} ssl - which protocol to use, defaults to false (HTTP)
+   * @param {string} pactfileWriteMode - 'overwrite' | 'update' | 'smart' | 'none', defaults to 'overwrite'
    */
-  constructor (consumer, provider, port, host, ssl) {
+  constructor (consumer, provider, port, host, ssl, pactfileWriteMode) {
     if (isNil(consumer) || isNil(provider)) {
       throw new Error('Please provide the names of the provider and consumer for this Pact.')
     }
@@ -27,12 +28,14 @@ module.exports = class MockService {
     port = port || 1234
     host = host || '127.0.0.1'
     ssl = ssl || false
+    pactfileWriteMode = pactfileWriteMode || 'overwrite'
 
     this._request = new Request()
     this._baseURL = `${ssl ? 'https' : 'http'}://${host}:${port}`
     this._pactDetails = {
       consumer: { name: consumer },
-      provider: { name: provider }
+      provider: { name: provider },
+      pactfile_write_mode: pactfileWriteMode
     }
   }
 

--- a/src/pact-web.d.ts
+++ b/src/pact-web.d.ts
@@ -1,5 +1,6 @@
 import { InteractionObject } from "./dsl/interaction";
 import * as _Matchers from "./dsl/matchers";
+import {PactfileWriteMode} from "./dsl/mockService";
 
 declare function pact(opts: pact.PactWebOptions): pact.PactWebProvider;
 
@@ -10,6 +11,7 @@ declare namespace pact {
     port?: number;
     host?: string;
     ssl?: boolean;
+    pactfileWriteMode?: PactfileWriteMode;
   }
 
   export interface PactWebProvider {

--- a/src/pact-web.js
+++ b/src/pact-web.js
@@ -22,6 +22,7 @@ var Interaction = require('./dsl/interaction')
  * @param {number} opts.port - port of the mock service, defaults to 1234
  * @param {string} opts.host - host address of the mock service, defaults to 127.0.0.1
  * @param {boolean} opts.ssl - SSL flag to identify the protocol to be used (default false, HTTP)
+ * @param {string} pactfileWriteMode - 'overwrite' | 'update' | 'smart' | 'none', defaults to 'overwrite'
  * @return {@link PactProvider}
  * @static
  */
@@ -40,10 +41,11 @@ module.exports = (opts) => {
   var port = opts.port || 1234
   var host = opts.host || '127.0.0.1'
   var ssl = opts.ssl || false
+  var pactfileWriteMode = opts.pactfileWriteMode || 'overwrite'
 
   logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on Port: "${port}"`)
 
-  const mockService = new MockService(consumer, provider, port, host, ssl)
+  const mockService = new MockService(consumer, provider, port, host, ssl, pactfileWriteMode)
 
   /** @namespace PactProvider */
   return {

--- a/src/pact.d.ts
+++ b/src/pact.d.ts
@@ -1,5 +1,6 @@
 import {InteractionObject} from "./dsl/interaction";
 import * as _Matchers from "./dsl/matchers";
+import {PactfileWriteMode} from "./dsl/mockService";
 import _Verifier = require("./dsl/verifier");
 
 declare function pact(opts: pact.PactOptions): pact.PactProvider;
@@ -18,6 +19,7 @@ declare namespace pact {
     logLevel?: string;
     spec?: number;
     cors?: boolean;
+    pactfileWriteMode?: PactfileWriteMode;
   }
 
   export interface PactProvider {

--- a/src/pact.js
+++ b/src/pact.js
@@ -29,6 +29,7 @@ const path = require('path')
  * @param {string} opts.host - host address of the mock service, defaults to 127.0.0.1
  * @param {boolean} opts.ssl - SSL flag to identify the protocol to be used (default false, HTTP)
  * @param {boolean} opts.cors - allow CORS OPTION requests to be accepted, defaults to false
+ * @param {string} pactfileWriteMode - 'overwrite' | 'update' | 'smart' | 'none', defaults to 'overwrite'
  * @return {@link PactProvider}
  * @static
  */
@@ -54,6 +55,7 @@ module.exports = (opts) => {
   const logLevel = opts.logLevel || 'INFO'
   const spec = opts.spec || 2
   const cors = opts.cors || false
+  const pactfileWriteMode = opts.pactfileWriteMode || 'overwrite'
 
   const server = serviceFactory.createServer({
     port: port,
@@ -69,7 +71,7 @@ module.exports = (opts) => {
 
   logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on Port: "${port}"`)
 
-  const mockService = new MockService(consumer, provider, port, host, ssl)
+  const mockService = new MockService(consumer, provider, port, host, ssl, pactfileWriteMode)
 
   /** @namespace PactProvider */
   return {


### PR DESCRIPTION
I want to use the [pactfile_write_mode feature](https://github.com/realestate-com-au/pact/blob/master/documentation/configuration.md#pactfile_write_mode) for separated test files.