### PR TITLE
docs(readme): improved example for asserting expectations on contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ describe('Pact', () => {
       	    expect(projects).to.be.a('array')
             expect(projects).to.have.deep.property('projects[0].id', 1)
 
-            // (5) validate the interactions occurred, this will throw an error if it fails telling you what went wrong
-      	    return provider.verify()
+            // (5) validate the interactions you've registered and expected occurred 
+            // this will throw an error if it fails telling you what went wrong
+      	    expect(provider.verify()).to.not.throw()
           })
       })
 


### PR DESCRIPTION
Fix #65 by asserting that the promise for `provider.verify()` hasn't thrown an error, thus providing a clearer example of usage for it.
