### PR TITLE
pass the pact dir to the server when writing pacts

### DIFF
--- a/src/dsl/mockService.d.ts
+++ b/src/dsl/mockService.d.ts
@@ -6,6 +6,7 @@ export class MockService {
   constructor(
     consumer: string,
     provider: string,
+    pactDir: string,
     port?: number,
     host?: string,
     ssl?: boolean,

--- a/src/dsl/mockService.js
+++ b/src/dsl/mockService.js
@@ -15,12 +15,13 @@ module.exports = class MockService {
   /**
    * @param {string} consumer - the consumer name
    * @param {string} provider - the provider name
+   * @param {string} pactDir - directory in which to write pacts
    * @param {number} port - the mock service port, defaults to 1234
    * @param {string} host - the mock service host, defaults to 127.0.0.1
    * @param {boolean} ssl - which protocol to use, defaults to false (HTTP)
    * @param {string} pactfileWriteMode - 'overwrite' | 'update' | 'none', defaults to 'overwrite'
    */
-  constructor (consumer, provider, port, host, ssl, pactfileWriteMode) {
+  constructor (consumer, provider, port, host, ssl, pactDir, pactfileWriteMode) {
     if (isNil(consumer) || isNil(provider)) {
       throw new Error('Please provide the names of the provider and consumer for this Pact.')
     }
@@ -35,6 +36,7 @@ module.exports = class MockService {
     this._pactDetails = {
       consumer: { name: consumer },
       provider: { name: provider },
+      pact_dir: pactDir,
       pactfile_write_mode: pactfileWriteMode
     }
   }

--- a/src/pact.js
+++ b/src/pact.js
@@ -71,7 +71,7 @@ module.exports = (opts) => {
 
   logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on Port: "${port}"`)
 
-  const mockService = new MockService(consumer, provider, port, host, ssl, pactfileWriteMode)
+  const mockService = new MockService(consumer, provider, dir, port, host, ssl, pactfileWriteMode)
 
   /** @namespace PactProvider */
   return {

--- a/src/pact.js
+++ b/src/pact.js
@@ -71,7 +71,7 @@ module.exports = (opts) => {
 
   logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on Port: "${port}"`)
 
-  const mockService = new MockService(consumer, provider, dir, port, host, ssl, pactfileWriteMode)
+  const mockService = new MockService(consumer, provider, port, host, ssl, dir, pactfileWriteMode)
 
   /** @namespace PactProvider */
   return {


### PR DESCRIPTION
The ruby `pact-mock-server` requires [pact_dir to be supplied](https://gist.github.com/bethesque/9d81f21d6f77650811f4#file-pact-details-json) when writing pacts, otherwise this error is encountered:

    Error: {"message":"Error ocurred in mock service: Pact::ConsumerContractWriterError - Please indicate the directory to write the pact to by specifying the pact_dir field","backtrace": ...}

The JS client was not sending that option, expecting to start a `pact-node` mock itself and configure its pact dir on construction. This change adds that option, so `pact-js` can be used with either mock service implementation.