### PR TITLE
README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,14 @@ the proper Node environment:
 }
 ```
 
+Also, [from Jest 20](https://facebook.github.io/jest/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner.html), you can add the environment to the top of the test file as a comment. This will allow your pact test to run along side the rest of your JSDOM env tests.
+
+```js
+/**
+ * @jest-environment node
+ */
+ ```
+
 See [this issue](https://github.com/pact-foundation/pact-js/issues/10) for background,
 and the Jest [example](https://github.com/pact-foundation/pact-js/blob/master/examples/jest/package.json#L10-L12) for a working example.
 


### PR DESCRIPTION
Jest 20 now supports setting the `node` test env within the file itself as a comment