### PR TITLE
feat(karma): relax consumer/provider requirement in MockService

### DIFF
--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -13,5 +13,10 @@ module.exports = {
     if (config.logging) {
       console.log(msg)
     }
+  },
+  warn: (msg) => {
+    if (config.logging) {
+      console.warn(msg)
+    }
   }
 }

--- a/src/dsl/mockService.d.ts
+++ b/src/dsl/mockService.d.ts
@@ -4,8 +4,8 @@ export type PactfileWriteMode = "overwrite" | "update" | "none";
 
 export class MockService {
   constructor(
-    consumer: string,
-    provider: string,
+    consumer?: string,
+    provider?: string,
     port?: number,
     host?: string,
     ssl?: boolean,

--- a/src/dsl/mockService.js
+++ b/src/dsl/mockService.js
@@ -9,6 +9,7 @@
 
 const isNil = require('lodash.isnil')
 const Request = require('../common/request')
+const logger = require('../common/logger')
 
 module.exports = class MockService {
 
@@ -22,7 +23,8 @@ module.exports = class MockService {
    */
   constructor (consumer, provider, port, host, ssl, pactfileWriteMode) {
     if (isNil(consumer) || isNil(provider)) {
-      throw new Error('Please provide the names of the provider and consumer for this Pact.')
+      logger.warn('Warning: Consumer\Provider details not provided, ensure ' +
+        'that the mock service has been started with this information')
     }
 
     port = port || 1234
@@ -33,9 +35,9 @@ module.exports = class MockService {
     this._request = new Request()
     this._baseURL = `${ssl ? 'https' : 'http'}://${host}:${port}`
     this._pactDetails = {
-      consumer: { name: consumer },
-      provider: { name: provider },
-      pactfile_write_mode: pactfileWriteMode
+      pactfile_write_mode: pactfileWriteMode,
+      consumer: (consumer) ? { name: consumer } : undefined,
+      provider: (provider) ? { name: provider } : undefined
     }
   }
 

--- a/src/pact-web.js
+++ b/src/pact-web.js
@@ -29,21 +29,16 @@ var Interaction = require('./dsl/interaction')
 module.exports = (opts) => {
   var consumer = opts.consumer
   var provider = opts.provider
-
-  if (isNil(consumer)) {
-    throw new Error('You must provide a Consumer for this pact.')
-  }
-
-  if (isNil(provider)) {
-    throw new Error('You must provide a Provider for this pact.')
-  }
-
   var port = opts.port || 1234
   var host = opts.host || '127.0.0.1'
   var ssl = opts.ssl || false
   var pactfileWriteMode = opts.pactfileWriteMode || 'overwrite'
 
-  logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on Port: "${port}"`)
+  if (isNil(consumer) || isNil(provider)) {
+    logger.info(`Setting up Pact using mock service on port: "${port}"`)
+  } else {
+    logger.info(`Setting up Pact with Consumer "${consumer}" and Provider "${provider}" using mock service on port: "${port}"`)
+  }
 
   const mockService = new MockService(consumer, provider, port, host, ssl, pactfileWriteMode)
 

--- a/test/common/logger.spec.js
+++ b/test/common/logger.spec.js
@@ -4,28 +4,35 @@ var proxyquire = require('proxyquire')
 
 describe('Logger#info', () => {
   const consoleLogSpy = sinon.spy(console, 'log')
+  const consoleWarnSpy = sinon.spy(console, 'warn')
 
   context('with logging configuration turned on', () => {
     beforeEach(() => {
       consoleLogSpy.reset()
+      consoleWarnSpy.reset()
       var logger = proxyquire('../../src/common/logger', { './config': { logging: true } })
       logger.info('this will be logged')
+      logger.warn('this will be logged at warn')
     })
 
     it('logs a message', () => {
       expect(consoleLogSpy).to.have.been.calledWith('this will be logged')
+      expect(consoleWarnSpy).to.have.been.calledWith('this will be logged at warn')
     })
   })
 
   context('with logging configuration turned off', () => {
     beforeEach(() => {
       consoleLogSpy.reset()
+      consoleWarnSpy.reset()
       var logger = proxyquire('../../src/common/logger', { './config': { logging: false } })
       logger.info('this will be ignored')
+      logger.warn('this will be logged at warn')
     })
 
     it('ignores a message to be logged', function () {
       expect(consoleLogSpy).to.not.have.been.called
+      expect(consoleWarnSpy).to.not.have.been.called
     })
   })
 })


### PR DESCRIPTION
See https://github.com/pact-foundation/karma-pact/pull/4#issuecomment-330108787 and https://github.com/pact-foundation/pact-js/issues/59#issuecomment-330183133 for background.

- For pact-web use cases, where mock service is started
  independently of the test cases themselves, we allow
  consumer and provider to be specified in underlying
  mock service directly.
- Logs warning to console if details aren't provided to
  assist in debugging issues
- Addresses pact-foundation/karma-pact/pull/4
- Addresses #59