### PR TITLE
fix(src): fix typo in error message

### DIFF
--- a/src/dsl/matchers.js
+++ b/src/dsl/matchers.js
@@ -45,7 +45,7 @@ module.exports.eachLike = (content, opts) => {
   }
 
   if (opts && (isNil(opts.min) || opts.min < 1)) {
-    throw new Error('Error creating a Pact eachLike. Please provide opts.min that is > 1')
+    throw new Error('Error creating a Pact eachLike. Please provide opts.min that is > 0')
   }
 
   return {


### PR DESCRIPTION
fix a typo in eachLike DSL matcher were comparison to < 1 would cause an error but error message
said > 1 which is incorrect