### PR TITLE
fix(verification): pass validation error message on 

### DIFF
--- a/src/pact-web.js
+++ b/src/pact-web.js
@@ -75,12 +75,7 @@ module.exports = (opts) => {
       return mockService.verify()
         .then(() => mockService.removeInteractions())
         .catch(e => {
-          // Properly format the error
-          console.error('')
-          console.error('Pact verification failed!')
-          console.error(e)
-
-          throw new Error('Pact verification failed - expected interactions did not match actual.')
+          throw new Error(e)
         })
     },
     /**

--- a/test/dsl/integration.spec.js
+++ b/test/dsl/integration.spec.js
@@ -249,7 +249,7 @@ describe('Integration', () => {
               .then(() => {}, (err) => { promiseResults.push(err.response) })
               .then(() => provider.verify(promiseResults))
 
-          expect(verificationPromise).to.be.rejectedWith('Error: Pact verification failed - expected interactions did not match actual.').notify(done)
+          expect(verificationPromise).to.be.rejected.notify(done)
         })
       })
     })


### PR DESCRIPTION
Verification error message is now passed on instead of being swallowed.

I'm not sure if it has any side effects, but at least for my use case (through karma-pact) this change made the experience of writing consumer tests much more pleasant, since I can now see what went wrong in the karma results in the browser.

fixes #113 