### PR TITLE
feat(pact-server): allow to run pact mock server on a host other than localhost

### DIFF
--- a/src/pact.js
+++ b/src/pact.js
@@ -58,6 +58,7 @@ module.exports = (opts) => {
   const pactfileWriteMode = opts.pactfileWriteMode || 'overwrite'
 
   const server = serviceFactory.createServer({
+    host: host,
     port: port,
     log: log,
     dir: dir,


### PR DESCRIPTION
When running pact tests (that also start the pact mock server) and the application code (that calls the APIs defined in the pact interactions) on different servers (or different docker containers), the pact server should be binded to a different host other than localhost, otherwise the API calls in the application won't reach the mock server.

pact constructor in src/pact.js already get a "host" option but it is not passed to serviceFactory.createServer() method.