### PR TITLE
Improve jest example. Use async and await instead promises.

### DIFF
--- a/examples/jest/.babelrc
+++ b/examples/jest/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-async-to-generator"]
+}

--- a/examples/jest/__tests__/index.spec.js
+++ b/examples/jest/__tests__/index.spec.js
@@ -19,12 +19,12 @@ describe("Dog's API", () => {
 
   const EXPECTED_BODY = [{dog: 1}]
 
-  beforeAll(() => provider.setup())
+  beforeAll(async () => await provider.setup())
 
-  afterAll(() => provider.finalize())
+  afterAll(async () => await provider.finalize())
 
   describe("works", () => {
-    beforeAll(done => {
+    beforeAll(async () => {
       const interaction = {
         state: 'i have a list of projects',
         uponReceiving: 'a request for projects',
@@ -39,21 +39,18 @@ describe("Dog's API", () => {
           body: EXPECTED_BODY
         }
       }
-      provider.addInteraction(interaction).then(done, done)
+      await provider.addInteraction(interaction)
     })
 
     // add expectations
-    it('returns a sucessful body', done => {
-      return getMeDogs({ url, port })
-        .then(response => {
-          expect(response.headers['content-type']).toEqual('application/json')
-          expect(response.data).toEqual(EXPECTED_BODY)
-          expect(response.status).toEqual(200)
-          done()
-        })
+    it('returns a sucessful body', async () => {
+      const response = await getMeDogs({url, port})
+      expect(response.headers['content-type']).toEqual('application/json')
+      expect(response.data).toEqual(EXPECTED_BODY)
+      expect(response.status).toEqual(200)
     })
 
     // verify with Pact, and reset expectations
-    it('successfully verifies', () => provider.verify())
+    it('successfully verifies', async () => await provider.verify())
   })
 })

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -12,6 +12,8 @@
   },
   "devDependencies": {
     "axios": "^0.14.0",
-    "jest-cli": "^15.1.1"
+    "babel-jest": "^21.2.0",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "jest-cli": "^21.2.1"
   }
 }


### PR DESCRIPTION
With the use of async and await the code becomes much more readable and easy to maintain.