### PR TITLE
feat(api) allow overriding what kind of request is constructed

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The `Pact` class provides the following high-level APIs, they are listed in the 
 | `spec` | no | number | Pact specification version (defaults to 2) |
 | `cors` | no | boolean | Allow CORS OPTION requests to be accepted, defaults to false |
 | `pactfileWriteMode` | no | string | Control how the Pact files are written. Choices: 'overwrite' 'update' or 'none'. Defaults to 'overwrite'|
+| `environment` | no | string | Control which environment pact will consider itself being ran in. Choices: 'web' or 'node'. Defaults to identifying environment by checking for the existence of `window` or `XMLHttpRequest` |
 
 #### Example
 The first step is to create a test for your API Consumer. The example below uses [Mocha](https://mochajs.org), and demonstrates the basic approach:

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.8.0",
     "typescript": "^2.4.2",
-    "webpack": "^3.5.5"
+    "webpack": "^3.5.5",
+    "xhr-mock": "2.0.0-preview.10"
   }
 }

--- a/src/common/environment.spec.ts
+++ b/src/common/environment.spec.ts
@@ -1,0 +1,32 @@
+/* tslint:disable:no-unused-expression no-empty */
+import * as chai from "chai";
+import * as sinon from "sinon";
+import mock from "xhr-mock";
+const expect = chai.expect;
+import { environment } from "./environment";
+
+describe("Environment", () => {
+  context("#isBrowserEnvironment", () => {
+    const g: any = global;
+
+    beforeEach(() => {
+      g.window = {};
+      mock.setup();
+    });
+
+    afterEach(() => {
+      mock.teardown();
+      g.window = undefined;
+    });
+
+    it("should consider it to be a browser environment", () => {
+      expect(environment.isBrowser()).to.be.true;
+    });
+  });
+
+  context("#isNodeEnvironment", () => {
+    it("should consider it to be a node environment", () => {
+      expect(environment.isNode()).to.be.true;
+    });
+  });
+});

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -1,0 +1,12 @@
+const environment = {
+  isBrowser: (): boolean => {
+    return (
+      typeof window !== "undefined" && typeof XMLHttpRequest === "function"
+    );
+  },
+  isNode: (): boolean => {
+    return typeof module !== "undefined" && !!module.exports;
+  },
+};
+
+export { environment };

--- a/src/dsl/mockService.ts
+++ b/src/dsl/mockService.ts
@@ -4,6 +4,7 @@
  * https://gist.github.com/bethesque/9d81f21d6f77650811f4.
  * @module MockService
  */
+import { Environment } from "dsl/options";
 import { isEmpty } from "lodash";
 import { logger } from "../common/logger";
 import { Request } from "../common/request";
@@ -43,9 +44,10 @@ export class MockService {
     private port = 1234,
     private host = "127.0.0.1",
     private ssl = false,
-    private pactfileWriteMode: PactfileWriteMode = "overwrite") {
+    private pactfileWriteMode: PactfileWriteMode = "overwrite",
+    private environment?: Environment) {
 
-    this.request = new Request();
+    this.request = new Request(environment);
     this.baseUrl = `${ssl ? "https" : "http"}://${host}:${port}`;
     this.pactDetails = {
       consumer: (consumer) ? { name: consumer } : undefined,

--- a/src/dsl/options.ts
+++ b/src/dsl/options.ts
@@ -44,6 +44,8 @@ export interface PactOptions {
   // Control how the Pact files are written
   // Choices: 'overwrite' | 'update', 'none', defaults to 'overwrite'
   pactfileWriteMode?: PactfileWriteMode;
+
+  environment?: Environment;
 }
 
 export interface MandatoryPactOptions {
@@ -53,3 +55,5 @@ export interface MandatoryPactOptions {
 }
 
 export type PactOptionsComplete = PactOptions & MandatoryPactOptions;
+
+export type Environment = "node" | "web";

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -75,7 +75,7 @@ export class Pact {
    using mock service on Port: "${this.opts.port}"`);
 
     this.mockService = new MockService(undefined, undefined, this.opts.port, this.opts.host,
-      this.opts.ssl, this.opts.pactfileWriteMode);
+                                       this.opts.ssl, this.opts.pactfileWriteMode, this.opts.environment);
   }
 
   /**


### PR DESCRIPTION
First of all I just wanted to say that when going through the code it is very legible and well-written!

## Background
We use `jest` to test our `angular` application and want to introduce pact-testing for the frontend-backend-communication. However, we run into the following problem:
- In order to run `angular` we need to have our environment set to `jsdom` due to `zone.js` patching XMLHttpRequest etc;
- In order to run `pact` we need to have our environment set to `node` (see #10 for further discussion and background).

I modified the code so that we always used `node`-style requests (ignoring environment checks) which got it working for us. With that in mind I thought it might be possible to add an ability to override the default behaviour, allowing us in scenarios such as these to run in the `jsdom` environment but tell `pact` to use `node`-style requests.

## System solution
This feature introduces an optional map of values to give when setting up the pact server. For now these options only contain one possible key: `environment`. The environment option can be used to force pact to use either a node-style request or a web-style request.

As part of this I also added `xhr-mock` and the ability to mock the `window`, which allowed running the test for `Request` preferring the `XMLHttpRequest` object.

If you think this is a good solution to go ahead with I can improve the tests a bit and document this new functionality in the readme.