### PR TITLE
fix(typescript) promotes es6-promise to a dependency as it's publically exposed

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@pact-foundation/pact-node": "^6.7.0",
     "cli-color": "^1.1.0",
+    "es6-promise": "^4.1.1",
     "lodash": "^4.17.4",
     "lodash.isfunction": "3.0.8",
     "lodash.isnil": "4.0.0",
@@ -112,7 +113,6 @@
     "chai-as-promised": "5.x",
     "coveralls": "^2.13.3",
     "enhanced-resolve": "^3.4.1",
-    "es6-promise": "^4.1.1",
     "imports-loader": "0.x",
     "istanbul": "0.4.x",
     "jasmine-core": "2.x",


### PR DESCRIPTION
`es6-promise` is used in the verifier, and thus needs to be a dependency of this package so
consumers can pickup the type definition.

I can confirm this fixes #142 regarding `es6-promise`. `bunyan` is missing from `pact-node` but I'll look at raising that separately.