### PR TITLE
Require '@pact-foundation/pact' in inline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Check out the `examples` folder for examples with Karma Jasmine, Mocha and Jest.
 ```javascript
 const path = require('path')
 const chai = require('chai')
-const { Pact } = require('pact')
+const { Pact } = require('@pact-foundation/pact')
 const chaiAsPromised = require('chai-as-promised')
 
 const expect = chai.expect


### PR DESCRIPTION
I think having this in the first example on the page would have cleared up a lot of problems from the start. An issue with me was going in quick running 'npm install pact-js' which would have put `pact` in my modules.

After installing the v5 @pact-foundation/pact I think my code references must have still been hitting v4.