### PR TITLE
Allow TS builder interface to work with literal interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Learn everything in Pact JS in 60 minutes: https://github.com/DiUS/pact-workshop
 * [Complete Example (Node env)](https://github.com/pact-foundation/pact-js/tree/master/examples/e2e)
 * [Pact with AVA (Node env)](https://github.com/pact-foundation/pact-js/tree/master/examples/ava)
 * [Pact with Jest (Node env)](https://github.com/pact-foundation/pact-js/tree/master/examples/jest)
+* [Pact with TypeScript + Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/typescript)
 * [Pact with Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/mocha)
 * [Pact with Karma + Jasmine](https://github.com/pact-foundation/pact-js/tree/master/karma/jasmine)
 * [Pact with Karma + Mocha](https://github.com/pact-foundation/pact-js/tree/master/karma/mocha)

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+export class DogService {
+  private url: string;
+  private port: number;
+
+  constructor(endpoint: any) {
+    this.url = endpoint.url;
+    this.port = endpoint.port;
+  }
+
+  public getMeDogs = (): Promise<any> => {
+    return axios.request({
+      baseURL: `${this.url}:${this.port}`,
+      headers: { Accept: "application/json" },
+      method: "GET",
+      url: "/dogs",
+    });
+  }
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "typescript-pact",
+  "version": "1.0.0",
+  "description": "TypeScript Pact Example",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "nyc --check-coverage --reporter=html --reporter=text-summary mocha"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/mocha": "^2.2.41",
+    "mocha": "3.x",
+    "nyc": "^11.2.0"
+  },
+  "dependencies": {
+    "axios": "^0.17.1"
+  }
+}

--- a/examples/typescript/test/get-dog.spec.ts
+++ b/examples/typescript/test/get-dog.spec.ts
@@ -1,0 +1,93 @@
+/* tslint:disable:no-unused-expression object-literal-sort-keys max-classes-per-file no-empty */
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import path = require("path");
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+import pact = require("../../../dist/pact");
+import { InteractionObject, Interaction } from "../../../dist/pact";
+
+const Pact = pact.Pact;
+const expect = chai.expect;
+const proxyquire = require("proxyquire").noCallThru();
+import { DogService } from "../index";
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+describe("The Dog API", () => {
+  const url = "http://localhost";
+  const port = 8989;
+  const dogService = new DogService({ url, port });
+
+  const provider = new Pact({
+    port,
+    log: path.resolve(process.cwd(), "logs", "mockserver-integration.log"),
+    dir: path.resolve(process.cwd(), "pacts"),
+    spec: 2,
+    consumer: "MyConsumer",
+    provider: "MyProvider",
+    pactfileWriteMode: "merge",
+  });
+
+  const EXPECTED_BODY = [{ dog: 1 }, { dog: 2 }];
+
+  before(() => provider.setup());
+
+  after(() => provider.finalize());
+
+  describe("get /dogs", () => {
+    before(() => {
+      const interaction = new Interaction()
+        .given("I have a list of dogs")
+        .uponReceiving("a request for all dogs")
+        .withRequest({
+          method: "GET",
+          path: "/dogs",
+          headers: {
+            Accept: "application/json",
+          },
+        })
+        .willRespondWith({
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: EXPECTED_BODY,
+        });
+      return provider.addInteraction(interaction);
+      // before(() => {
+      //   const interaction = {
+      //     state: "i have a list of dogs",
+      //     uponReceiving: "a request for all dogs",
+      //     withRequest: {
+      //       method: "GET",
+      //       path: "/dogs",
+      //       headers: {
+      //         Accept: "application/json",
+      //       },
+      //     },
+      //     willRespondWith: {
+      //       status: 200,
+      //       headers: {
+      //         "Content-Type": "application/json",
+      //       },
+      //       body: EXPECTED_BODY,
+      //     },
+      //   } as InteractionObject;
+      //   return provider.addInteraction(interaction);
+      // });
+
+      it("returns the correct response", (done) => {
+        dogService
+          .getMeDogs()
+          .then((response: any) => {
+            expect(response.data).to.eql(EXPECTED_BODY);
+            done();
+          }, done);
+      });
+
+      // verify with Pact, and reset expectations
+      afterEach(() => provider.verify());
+    });
+  });

--- a/examples/typescript/test/helper.ts
+++ b/examples/typescript/test/helper.ts
@@ -1,0 +1,6 @@
+import wrapper from "@pact-foundation/pact-node";
+
+// used to kill any left over mock server instances
+process.on("SIGINT", () => {
+  wrapper.removeAllServers();
+});

--- a/examples/typescript/test/mocha.opts
+++ b/examples/typescript/test/mocha.opts
@@ -1,0 +1,11 @@
+--bail
+--compilers ts:ts-node/register
+--require ./test/helper.ts
+--require ts-node/register
+--require source-map-support/register
+--full-trace
+--reporter spec
+--colors
+--recursive
+--timeout 10000
+test/*.spec.ts

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "src",
+    "sourceMap": true,
+    "noLib": false,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "emitDecoratorMetadata": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "target": "es5",
+    "lib": [
+      "es2016",
+      "dom"
+    ]
+  },
+  "include": [
+    "./**/*"
+  ],
+  "exclude": [
+    "./node_modules/**/*",
+    "./dist",
+    "./examples",
+    "test/*.spec.ts"
+  ]
+}

--- a/examples/typescript/tslint.json
+++ b/examples/typescript/tslint.json
@@ -1,0 +1,12 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended"
+  ],
+  "jsRules": {},
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "no-var-requires": false
+  },
+  "rulesDirectory": []
+}

--- a/package.json
+++ b/package.json
@@ -18,15 +18,17 @@
     "prerelease": "npm i && rm package-lock.json",
     "release": "standard-version",
     "test": "nyc --check-coverage --reporter=html --reporter=text-summary mocha",
-    "test:examples": "npm run test:e2e-examples && npm run test:jest-examples && npm run test:mocha-examples && npm run test:ava-examples",
+    "test:examples": "npm run test:e2e-examples && npm run test:jest-examples && npm run test:mocha-examples && npm run test:ava-examples && npm run test:ts-examples",
     "test:e2e-examples": "cd examples/e2e && npm i && npm t",
     "test:ava-examples": "cd examples/ava && npm i && npm t",
     "test:jest-examples": "cd examples/jest && npm i && npm t",
     "test:mocha-examples": "cd examples/mocha && npm i && npm t",
+    "test:ts-examples": "cd examples/typescript && npm i && npm t",
     "test:karma": "npm run test:karma:jasmine && npm run test:karma:mocha",
     "test:karma:jasmine": "karma start ./karma/jasmine/karma.conf.js",
     "test:karma:mocha": "karma start ./karma/mocha/karma.conf.js",
     "travis": "./scripts/build.sh",
+    "appveyor": "./scripts/build.ps1",
     "webpack": "webpack --config ./config/webpack.web.config.js"
   },
   "repository": {
@@ -45,8 +47,7 @@
     "consumer driven testing"
   ],
   "author": "Beth Skurrie <beth@bethesque.com> (https://github.com/bethesque)",
-  "contributors": [
-    {
+  "contributors": [{
       "name": "Tarcio Saraiva",
       "email": "tarcio@gmail.com",
       "url": "http://twitter.com/tarciosaraiva"

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -118,6 +118,8 @@ export class Interaction {
       headers: responseOpts.headers || undefined,
       status: responseOpts.status,
     }, isNil) as ResponseOptions;
+
+    return this;
   }
 
   /**

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -118,7 +118,6 @@ export class Interaction {
       headers: responseOpts.headers || undefined,
       status: responseOpts.status,
     }, isNil) as ResponseOptions;
-
     return this;
   }
 

--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -169,6 +169,31 @@ describe("Pact", () => {
         interactionWithNoState.state = undefined;
         expect(pact.addInteraction(interaction)).to.eventually.not.have.property("providerState").notify(done);
       });
+
+      describe("when given an Interaction as a builder", () => {
+        it("creates interaction", (done) => {
+          const interaction2 = new Interaction()
+            .given("i have a list of projects")
+            .uponReceiving("a request for projects")
+            .withRequest({
+              method: "GET",
+              path: "/projects",
+              headers: { Accept: "application/json" },
+            })
+            .willRespondWith({
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+              body: {},
+            });
+
+          const pact = Object.create(Pact.prototype) as any as PactType;
+          pact.opts = fullOpts;
+          pact.mockService = {
+            addInteraction: (int: Interaction): Promise<Interaction> => Promise.resolve(int),
+          } as any as MockService;
+          expect(pact.addInteraction(interaction2)).to.eventually.have.property("given").notify(done);
+        });
+      });
     });
   });
 

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -93,17 +93,22 @@ export class Pact {
    * @param {Interaction} interactionObj
    * @returns {Promise}
    */
-  public addInteraction(interactionObj: InteractionObject): Promise<string> {
-    const interaction = new Interaction();
+  public addInteraction(interactionObj: InteractionObject | Interaction): Promise<string> {
+    let interaction: Interaction;
 
-    if (interactionObj.state) {
-      interaction.given(interactionObj.state);
+    // tslint:disable:no-angle-bracket-type-assertion
+    if (<InteractionObject>(<any>interactionObj).state) {
+      interaction = new Interaction();
+      if (interactionObj.state) {
+        interaction.given(interactionObj.state);
+      }
+
+      interaction
+        .uponReceiving(interactionObj.uponReceiving)
+        .withRequest(interactionObj.withRequest)
+        .willRespondWith(interactionObj.willRespondWith);
     }
 
-    interaction
-      .uponReceiving(interactionObj.uponReceiving)
-      .withRequest(interactionObj.withRequest)
-      .willRespondWith(interactionObj.willRespondWith);
 
     return this.mockService.addInteraction(interaction);
   }

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -94,21 +94,18 @@ export class Pact {
    * @returns {Promise}
    */
   public addInteraction(interactionObj: InteractionObject | Interaction): Promise<string> {
-    let interaction: Interaction;
-
-    // tslint:disable:no-angle-bracket-type-assertion
-    if (<InteractionObject>(<any>interactionObj).state) {
-      interaction = new Interaction();
-      if (interactionObj.state) {
-        interaction.given(interactionObj.state);
-      }
-
-      interaction
-        .uponReceiving(interactionObj.uponReceiving)
-        .withRequest(interactionObj.withRequest)
-        .willRespondWith(interactionObj.willRespondWith);
+    if (interactionObj instanceof Interaction) {
+      return this.mockService.addInteraction(interactionObj);
+    }
+    const interaction = new Interaction();
+    if (interactionObj.state) {
+      interaction.given(interactionObj.state);
     }
 
+    interaction
+      .uponReceiving(interactionObj.uponReceiving)
+      .withRequest(interactionObj.withRequest)
+      .willRespondWith(interactionObj.willRespondWith);
 
     return this.mockService.addInteraction(interaction);
   }


### PR DESCRIPTION
Cleans up the Type interface for TS usage, in a backwards-compatible way:

- `pact.addInteraction()` now accepts union type InteractionObject | Interaction
- Builder pattern as first-class citizen (exported as Interaction)
- Add TypeScript example demonstrating both builder and literal examples