### PR TITLE
Fix import in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Often times, you find yourself having to re-write regular expressions for common
 #### Match based on type
 
 ```javascript
-const { like } = pact
+const { like } = Matchers
 
 provider.addInteraction({
   state: 'Has some animals',


### PR DESCRIPTION
The example shows "like" being imported from 'pact'; it should be imported from "Matchers"