### PR TITLE
e2e example: Update keys for setting local/remote pact files in verifyProvider opts

### DIFF
--- a/examples/e2e/test/provider.spec.js
+++ b/examples/e2e/test/provider.spec.js
@@ -48,9 +48,9 @@ describe('Pact Verification', () => {
       // Fetch from broker with given tags
       tags: ['prod', 'sit5'],
       // Specific Remote pacts (doesn't need to be a broker)
-      // pactFilesOrDirs: ['https://test.pact.dius.com.au/pacts/provider/Animal%20Profile%20Service/consumer/Matching%20Service/latest'],
+      // pactUrls: ['https://test.pact.dius.com.au/pacts/provider/Animal%20Profile%20Service/consumer/Matching%20Service/latest'],
       // Local pacts
-      // pactFilesOrDirs: [path.resolve(process.cwd(), './pacts/matching_service-animal_profile_service.json')],
+      // pactUrls: [path.resolve(process.cwd(), './pacts/matching_service-animal_profile_service.json')],
       pactBrokerUsername: 'dXfltyFMgNOFZAxr8io9wJ37iUpY42M',
       pactBrokerPassword: 'O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1',
       publishVerificationResult: true,


### PR DESCRIPTION
It appears that pact-node allows specifying local (file, or directory path) or remote (url) locations of pact files under the `pactUrls` key.

When playing around with the e2e example, uncommenting the relevant lines (using them as an example) resulted in errors. (See my comment on pact-foundation/pact-node/issues/78, for details regarding my setup, and the exact error)

Updating the example keys to `pactUrls` resolved issues for me.

As this updates commented-out code, I couldn't figure out a quick & graceful way of `testing` it (other than manual checks). I notice that [pact-foundation/pact-node/blob/master/src/verifier.spec.ts](https://github.com/pact-foundation/pact-node/blob/master/src/verifier.spec.ts) includes some examples using `pactUrls`.