### PR TITLE
fix: Resolve package.json for version metadata regardless of nesting

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "consumer driven testing"
   ],
   "author": "Matt Fellows <m@onegeek.com.au> (http://twitter.com/matthewfellows)",
-  "contributors": [{
+  "contributors": [
+    {
       "name": "Tarcio Saraiva",
       "email": "tarcio@gmail.com",
       "url": "http://twitter.com/tarciosaraiva"
@@ -95,6 +96,7 @@
     "lodash.isundefined": "3.0.1",
     "lodash.omit": "^4.5.0",
     "lodash.omitby": "4.6.0",
+    "packpath": "^0.1.0",
     "popsicle": "^9.2.0"
   },
   "devDependencies": {

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,7 +1,12 @@
 import * as bunyan from "bunyan";
 const PrettyStream = require("bunyan-prettystream");
 
-const pkg = require("../../package.json");
+const path = require("path");
+const packpath = require("packpath");
+
+// Look up package.json regardless of nesting
+const manifestFile = path.join(packpath.self(), "package.json");
+const pkg = require(manifestFile);
 const prettyStdOut = new PrettyStream();
 prettyStdOut.pipe(process.stdout);
 


### PR DESCRIPTION
The package.json file appears at a different relative location in the source tree versus the compiled package.
It should be resolved regardless of the level of nesting present in the calling module.

Relates to https://github.com/pact-foundation/pact-js/issues/173