### PR TITLE
fix(interaction): include response body if set to empty string

### DIFF
--- a/src/dsl/interaction.spec.ts
+++ b/src/dsl/interaction.spec.ts
@@ -87,6 +87,26 @@ describe("Interaction", () => {
         expect(actual.request).to.have.keys("method", "path", "query", "headers", "body");
       });
     });
+
+    describe("request body", () => {
+      it("is included when an empty string is specified", () => {
+        const actual = new Interaction().withRequest({
+          body: "",
+          method: HTTPMethod.GET,
+          path: "/path",
+        }).json();
+        expect(actual.request).to.have.any.keys("body");
+      });
+
+      it("is not included when explicitly set to undefined", () => {
+        const actual = new Interaction().withRequest({
+          body: undefined,
+          method: HTTPMethod.GET,
+          path: "/path",
+        }).json();
+        expect(actual.request).not.to.have.any.keys("body");
+      });
+    });
   });
 
   describe("#willRespondWith", () => {
@@ -129,6 +149,28 @@ describe("Interaction", () => {
       it("has a full state all available keys", () => {
         expect(actual).to.have.keys("response");
         expect(actual.response).to.have.keys("status", "headers", "body");
+      });
+    });
+
+    describe("response body", () => {
+      it("is included when an empty string is specified", () => {
+        interaction = new Interaction();
+        interaction.willRespondWith({
+          body: "",
+          status: 204,
+        });
+        const actual = interaction.json();
+        expect(actual.response).to.have.any.keys("body");
+      });
+
+      it("is not included when explicitly set to undefined", () => {
+        interaction = new Interaction();
+        interaction.willRespondWith({
+          body: undefined,
+          status: 204,
+        });
+        const actual = interaction.json();
+        expect(actual.response).not.to.have.any.keys("body");
       });
     });
   });

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -106,7 +106,7 @@ export class Interaction {
     }
 
     this.state.response = omitBy({
-      body: responseOpts.body || undefined,
+      body: responseOpts.body,
       headers: responseOpts.headers || undefined,
       status: responseOpts.status,
     }, isNil) as ResponseOptions;


### PR DESCRIPTION
Fixes #177 
The problem existed only for response bodies, but I also added tests for request bodies so as to prevent a regression.