### PR TITLE
chore(docs): update directions in jest example readme

### DIFF
--- a/examples/jest/README.md
+++ b/examples/jest/README.md
@@ -1,6 +1,8 @@
 # Jest Example
 
-1. In the pact-js project root, change to the `examples/jest` directory
+1. In the pact-js project root, run: `npm i`
+1. Run: `npm run compile`
+1. Change to the `examples/jest` directory.
 1. Run: `npm i`
 1. Run the tests: `npm t`
 
@@ -17,4 +19,3 @@ pactfileWriteMode: 'update'
 in the provider to get pacts appended to.
 
 Also note the publish is a separate task. As there is no real afterAll it is difficult to know when to publish in normal running so I had to extract it.
-


### PR DESCRIPTION
This would have saved me some time getting the example to work. Without the first two steps, I was getting this error:

```
bash> npm t

> jest@1.0.0 test /Users/chris/projects/other/pact-js/examples/jest
> jest __tests__/ --runInBand --setupFiles ./pactSetup.js --setupTestFrameworkScriptFile ./pactTestWrapper.js

 FAIL  __tests__/another.spec.js
  ● Test suite failed to run

    Cannot find module '../../dist/pact' from 'pactSetup.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous> (pactSetup.js:2:12)

 FAIL  __tests__/index.spec.js
  ● Test suite failed to run

    Cannot find module '../../dist/pact' from 'pactSetup.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous> (pactSetup.js:2:12)

Test Suites: 2 failed, 2 total
Tests:       0 total
Snapshots:   0 total
Time:        0.068s, estimated 3s
Ran all test suites matching /__tests__\//i.
npm ERR! Test failed.  See above for more details.
```