### PR TITLE
close http server instance started by Message Provider Verifier

### DIFF
--- a/src/messageProviderPact.ts
+++ b/src/messageProviderPact.ts
@@ -46,10 +46,10 @@ export class MessageProviderPact {
     // Run the verification once the proxy server is available
     return this.waitForServerReady(server)
       .then(this.runProviderVerification())
-      .then(((result) => {
+      .then((result) => {
         server.close();
         return result;
-      }));
+      });
   }
 
   // Listens for the server start event

--- a/src/messageProviderPact.ts
+++ b/src/messageProviderPact.ts
@@ -44,7 +44,12 @@ export class MessageProviderPact {
     const server = this.setupProxyServer(app);
 
     // Run the verification once the proxy server is available
-    return this.waitForServerReady(server).then(this.runProviderVerification());
+    return this.waitForServerReady(server)
+      .then(this.runProviderVerification())
+      .then(((result) => {
+        server.close();
+        return result;
+      }));
   }
 
   // Listens for the server start event


### PR DESCRIPTION
When running MessageProvider tests using Jest the test pack never quits. This has been narrowed down to a http server that is started when calling the verify() method but is never closed. A small
change to ensure that the server gets shut down correctly after the verification has been completed.