### PR TITLE
Fix/typescript example

### DIFF
--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+import axios, { AxiosPromise } from "axios";
+
 
 export class DogService {
   private url: string;
@@ -9,7 +10,7 @@ export class DogService {
     this.port = endpoint.port;
   }
 
-  public getMeDogs = (): Promise<any> => {
+  public getMeDogs = (): AxiosPromise => {
     return axios.request({
       baseURL: `${this.url}:${this.port}`,
       headers: { Accept: "application/json" },

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -11,10 +11,11 @@
   "license": "MIT",
   "devDependencies": {
     "@types/mocha": "^2.2.41",
-    "mocha": "3.x",
-    "nyc": "^11.2.0"
+    "mocha": "^3.5.3",
+    "nyc": "^11.9.0"
   },
   "dependencies": {
-    "axios": "^0.17.1"
+    "axios": "^0.17.1",
+    "typescript": "^3.0.3"
   }
 }


### PR DESCRIPTION
Node Version : 10.11.0
Operating System: MacOS High Sierra (10.13.6)

- Fixes the build issue
<img width="747" alt="screen shot 2018-09-27 at 1 27 53 pm" src="https://user-images.githubusercontent.com/1627280/46122671-59415100-c25d-11e8-9e37-08de1c20dc2e.png">

- Fixes the test command failing
<img width="714" alt="screen shot 2018-09-27 at 2 03 23 pm" src="https://user-images.githubusercontent.com/1627280/46122810-33687c00-c25e-11e8-86f0-15f6d9c18a22.png">

- Fixes the incorrect typing
```js
Promise<Any> 
```
is not used by axios. But the following type is used
```js
AxiosPromise
```