### PR TITLE
fix(interaction-failure): clear interactions on any verify()

### DIFF
--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -245,7 +245,7 @@ describe("Pact", () => {
         const verifyPromise = b.verify();
         return Promise.all([
           expect(verifyPromise).to.eventually.be.rejectedWith(Error),
-          verifyPromise.catch(() => expect(removeInteractionsStub).to.callCount(0)),
+          verifyPromise.catch(() => expect(removeInteractionsStub).to.callCount(1)),
         ]);
       });
     });

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -127,6 +127,7 @@ export class Pact {
     return this.mockService.verify()
       .then(() => this.mockService.removeInteractions())
       .catch((e: any) => {
+
         // Properly format the error
         /* tslint:disable: no-console */
         console.error("");
@@ -134,8 +135,10 @@ export class Pact {
         console.error(clc.red(e));
         /* tslint:enable: */
 
-        throw new Error("Pact verification failed - expected interactions did not match actual.");
-      });
+        return this.mockService.removeInteractions().then(() => {
+          throw new Error("Pact verification failed - expected interactions did not match actual.");
+        })
+      })
   }
 
   /**


### PR DESCRIPTION
All successful/failed calls to pact.verify() should clear
interactions so that subsequent tests don't det out of whack.

NOTE: Promise.finally() would have been nicer, note for
upgrade to latest TS in next major release.

Fixes #231