### PR TITLE
fix(matchers): Allow integers/decimals to be 0

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -421,6 +421,7 @@ describe("Matcher", () => {
       it("should not fail", () => {
         expect(decimal(10.1)).to.be.an("object");
         expect(decimal()).to.be.an("object");
+        expect(decimal(0.00).contents).to.equal(0.00);
       });
     });
   });
@@ -430,6 +431,7 @@ describe("Matcher", () => {
       it("should not fail", () => {
         expect(integer(10)).to.be.an("object");
         expect(integer()).to.be.an("object");
+        expect(integer(0).contents).to.equal(0);
       });
     });
   });

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -171,7 +171,7 @@ export function hexadecimal(hex?: string) {
  * @param {float} float - a decimal value.
  */
 export function decimal(float?: number) {
-  return somethingLike<number>(float || 13.01);
+  return somethingLike<number>(isNil(float) ? 13.01 : float);
 }
 
 /**
@@ -179,7 +179,7 @@ export function decimal(float?: number) {
  * @param {integer} int - an int value.
  */
 export function integer(int?: number) {
-  return somethingLike<number>(int || 13);
+  return somethingLike<number>(isNil(int) ? 13 : int);
 }
 
 /**


### PR DESCRIPTION
Due to how javascript deals with 0 in if statements passing 0 into `integer()/decimal()` results in
the default value 13. This change corrects that by doing a nil check instead