### PR TITLE
fix(vulnerabilities): upgrade version of pact-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-node": "^6.16.1",
+    "@pact-foundation/pact-node": "^6.20.0",
     "@types/express": "^4.11.1",
     "body-parser": "^1.18.2",
     "bunyan": "^1.8.12",


### PR DESCRIPTION
Including the current version of `pact-js` in a github project results in security warnings for contributors. (See [here](https://github.com/pact-foundation/pact-node/pull/131) for details).

This PR fixes those warnings by upgrading pact-node.