### PR TITLE
fix(logger): apply logLevel value passed via constructor

### DIFF
--- a/src/pact.ts
+++ b/src/pact.ts
@@ -13,6 +13,7 @@ import { Interaction, InteractionObject } from "./dsl/interaction";
 import { isEmpty } from "lodash";
 import { isPortAvailable } from "./common/net";
 import logger from "./common/logger";
+import { LogLevels } from "@pact-foundation/pact-node/src/logger";
 import { MockService } from "./dsl/mockService";
 import { PactOptions, PactOptionsComplete } from "./dsl/options";
 import { Server } from "@pact-foundation/pact-node/src/server";
@@ -60,6 +61,7 @@ export class Pact {
       throw new Error("You must specify a Provider for this pact.");
     }
 
+    logger.level(this.opts.logLevel as LogLevels);
     serviceFactory.logLevel(this.opts.logLevel);
     this.server = serviceFactory.createServer({
       consumer: this.opts.consumer,


### PR DESCRIPTION
Currently, `logLevel` is passed only downstream to pact-node and not respected by a local logger.

Steps to reproduce:

```
const path = require('path');
const { Pact } = require('@pact-foundation/pact');

const provider = new Pact({
  port: 9999,
  host: '0.0.0.0',
  cors: true,
  log: path.resolve(process.cwd(), 'pact.log'),
  dir: path.resolve(process.cwd(), 'pacts'),
  logLevel: 'fatal',
  consumer: 'consumer',
  provider: 'provider'
});
```
Expected: no logs in STDOUT
Actual: INFO logs in stdout.

This PR fixes the issue.