### PR TITLE
iso8601DateTimeWithMillis: allow variable length fractional precision

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -505,6 +505,7 @@ describe("Matcher", () => {
       describe("when given a valid iso8601DateTimeWithMillis", () => {
         it("should not fail", () => {
           expect(iso8601DateTimeWithMillis("2015-08-06T16:53:10.123+01:00")).to.be.an("object");
+          expect(iso8601DateTimeWithMillis("2015-08-06T16:53:10.537357Z")).to.be.an("object");
           expect(iso8601DateTimeWithMillis()).to.be.an("object");
         });
       });

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -11,7 +11,7 @@ import { isFunction, isNil, isEmpty, isUndefined } from "lodash";
 /* tslint:disable:max-line-length */
 export const ISO8601_DATE_FORMAT = "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$";
 export const ISO8601_DATETIME_FORMAT = "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$";
-export const ISO8601_DATETIME_WITH_MILLIS_FORMAT = "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d:[0-5]\\d|Z)$";
+export const ISO8601_DATETIME_WITH_MILLIS_FORMAT = "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z)$";
 export const ISO8601_TIME_FORMAT = "^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$";
 export const RFC3339_TIMESTAMP_FORMAT = "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$";
 export const UUID_V4_FORMAT = "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$";


### PR DESCRIPTION
I was attempting to use the iso8601DateTimeWithMillis matcher on a field like `2018-11-21T14:44:31.537357Z`, which was being returned from a Go service, but the match was failing.

Currently, iso8601DateTimeWithMillis only allows the precision of the ISO8601 fractional seconds to 3 decimal places, this PR allows any number of decimal places.

I'm slightly unsure of this PR as the function is named `...WithMillis`, but this PR will allow precisions greater than a millisecond. I didn't want to break backwards compatibility, so renaming the function wasn't an option, but maybe it could live as a separate function like `iso8601DateTimeWithFractionalSecond`. Be interested to hear your thoughts.