### PR TITLE
feat(apollo-graphql): add Apollo specific GraphQL interface. 

### DIFF
--- a/examples/graphql/consumer.spec.ts
+++ b/examples/graphql/consumer.spec.ts
@@ -3,7 +3,8 @@ import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { like, term } from "../../src/dsl/matchers";
 import { query } from "./consumer";
-import { Pact, GraphQLInteraction } from "../../src/pact";
+import { Pact, GraphQLInteraction, ApolloGraphQLInteraction } from "../../src/pact";
+// import gql from "graphql-tag";
 
 const path = require("path");
 const expect = chai.expect;
@@ -26,7 +27,11 @@ describe("GraphQL example", () => {
     before(() => {
       const graphqlQuery = new GraphQLInteraction()
         .uponReceiving("a hello request")
-        .withQuery(`query HelloQuery { hello }`)
+        .withQuery(`
+          query HelloQuery {
+            hello
+          }
+        `)
         .withOperation('HelloQuery')
         .withRequest({
           path: "/graphql",

--- a/examples/graphql/consumer.ts
+++ b/examples/graphql/consumer.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, HttpLink } from "apollo-boost";
+import { ApolloClient } from "apollo-boost";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import gql from "graphql-tag";
 import { createHttpLink } from "apollo-link-http";

--- a/src/dsl/apolloGraphql.spec.ts
+++ b/src/dsl/apolloGraphql.spec.ts
@@ -1,0 +1,52 @@
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { ApolloGraphQLInteraction } from "./apolloGraphql";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe("ApolloGraphQLInteraction", () => {
+  let interaction: ApolloGraphQLInteraction;
+
+  beforeEach(() => {
+    interaction = new ApolloGraphQLInteraction();
+  });
+
+  describe("#withVariables", () => {
+    describe("when given a set of variables", () => {
+      it("should add the variables to the payload", () => {
+        interaction.uponReceiving("a request");
+        interaction.withOperation("query");
+        interaction.withQuery("{ hello }");
+        interaction.withVariables({
+          foo: "bar"
+        });
+
+        const json: any = interaction.json();
+        expect(json.request.body.variables).to.deep.eq({ foo: "bar" });
+      });
+    });
+    describe("when no variables are presented", () => {
+      it("should add an empty variables property to the payload", () => {
+        interaction.uponReceiving("a request");
+        interaction.withOperation("query");
+        interaction.withQuery("{ hello }");
+
+        const json: any = interaction.json();
+        expect(json.request.body).to.have.property("variables");
+      });
+    });
+  });
+
+  describe("#withOperation", () => {
+    describe("when no operationNaame is presented", () => {
+      it("should add a null operationName property to the payload", () => {
+        interaction.uponReceiving("a request");
+        interaction.withQuery("{ hello }");
+
+        const json: any = interaction.json();
+        expect(json.request.body).to.have.property("operationName");
+      });
+    });
+  });
+});

--- a/src/dsl/apolloGraphql.ts
+++ b/src/dsl/apolloGraphql.ts
@@ -1,0 +1,9 @@
+import { GraphQLInteraction } from './graphql'
+
+export class ApolloGraphQLInteraction extends GraphQLInteraction {
+  constructor() {
+    super()
+    this.variables = this.variables || {}
+    this.operation = this.operation || null
+  }
+}

--- a/src/dsl/graphql.spec.ts
+++ b/src/dsl/graphql.spec.ts
@@ -1,8 +1,7 @@
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { GraphQLInteraction } from "./graphql";
-import { Interaction } from "../pact";
-import { isMatcher, regex } from "./matchers";
+import { isMatcher } from "./matchers";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -63,6 +62,17 @@ describe("GraphQLInteraction", () => {
 
         const json: any = interaction.json();
         expect(json.request.body).to.not.have.property("variables");
+      });
+    });
+    describe("when an empty variables object is presented", () => {
+      it("should add the variables property to the payload", () => {
+        interaction.uponReceiving("a request");
+        interaction.withOperation("query");
+        interaction.withQuery("{ hello }");
+        interaction.withVariables({})
+
+        const json: any = interaction.json();
+        expect(json.request.body).to.have.property("variables");
       });
     });
   });

--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -5,7 +5,7 @@
  */
 import { Interaction, InteractionState } from "../dsl/interaction";
 import { regex } from "./matchers";
-import { isNil, extend, omitBy, isEmpty } from "lodash";
+import { isNil, extend, omitBy, isUndefined } from "lodash";
 import gql from "graphql-tag";
 
 export interface GraphQLVariables { [name: string]: any; }
@@ -14,9 +14,9 @@ export interface GraphQLVariables { [name: string]: any; }
  * GraphQL interface
  */
 export class GraphQLInteraction extends Interaction {
-  private operation: string;
-  private variables: GraphQLVariables = {};
-  private query: string;
+  protected operation?: string | null = undefined;
+  protected variables?: GraphQLVariables = undefined;
+  protected query: string;
 
   /**
    * The type of GraphQL operation. Generally not required.
@@ -83,10 +83,10 @@ export class GraphQLInteraction extends Interaction {
 
     this.state.request = extend({
       body: omitBy({
-        operationName: this.operation || null,
+        operationName: this.operation,
         query: regex({ generate: this.query, matcher: escapeGraphQlQuery(this.query) }),
         variables: this.variables,
-      }, isEmpty),
+      }, isUndefined),
       headers: { "content-type": "application/json" },
       method: "POST",
     }, this.state.request);

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -208,14 +208,14 @@ export function eachLike<T>(content: T, opts?: { min: number }) {
     contents: content,
     getValue: () => {
       const data = [];
-      const min = isUndefined(opts) ? 1 : opts.min;
+      const min = (!opts) ? 1 : opts.min;
       for (let i = 0; i < min; i++) {
         data[i] = content;
       }
       return data;
     },
     json_class: "Pact::ArrayLike",
-    min: isUndefined(opts) ? 1 : opts.min,
+    min: (!opts) ? 1 : opts.min,
   };
 }
 

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -207,6 +207,7 @@ export * from "./dsl/verifier";
  * @static
  */
 export * from "./dsl/graphql";
+export * from "./dsl/apolloGraphql";
 
 /**
  * Exposes {@link Matchers}


### PR DESCRIPTION
Separates the GraphQL Interaction interface into two, and sets reasonable defaults based on the discussion in #254 and #243. Changes: 

* Defaults `variables` and `operationName` to `undefined`
* Any `undefined` properties are not marshalled in interaction, but _falsey_ things will
* `GraphQLInteraction` - base class for GraphQL interactions (minor changes)
* `ApolloGraphQLInteraction` - tiny enhancement on the base class to default variables to `{}` and `operationName` to `null`, to match default behaviour (new)

@tomasAlabes @ngbrown how does this look to you?