### PR TITLE
docs(README): remove refs to old branch and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ describe("receive dog event", () => {
 1.  Creates the MessageConsumer class
 1.  Setup the expectations for the consumer - here we expect a `dog` object with three fields
 1.  Pact will send the message to your message handler. If the handler returns a successful promise, the message is saved, otherwise the test fails. There are a few key things to consider:
-    * The actual request body that Pact will send, will be contained within a [Message](https://github.com/pact-foundation/pact-js/tree/feat/message-pact/src/dsl/message.ts) object along with other context, so the body must be retrieved via `content` attribute.
+    * The actual request body that Pact will send, will be contained within a [Message](https://github.com/pact-foundation/pact-js/tree/master/src/dsl/message.ts) object along with other context, so the body must be retrieved via `content` attribute.
     * All handlers to be tested must be of the shape `(m: Message) => Promise<any>` - that is, they must accept a `Message` and return a `Promise`. This is how we get around all of the various protocols, and will often require a lightweight adapter function to convert it.
     * In this case, we wrap the actual dogApiHandler with a convenience function `synchronousBodyHandler` provided by Pact, which Promisifies the handler and extracts the contents.
 
@@ -678,14 +678,14 @@ Learn everything in Pact JS in 60 minutes: https://github.com/DiUS/pact-workshop
 * [Pact with Jest (Node env)](https://github.com/pact-foundation/pact-js/tree/master/examples/jest)
 * [Pact with TypeScript + Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/typescript)
 * [Pact with Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/mocha)
-* [Pact with GraphQL](https://github.com/pact-foundation/pact-js/tree/feat/message-pact/examples/graphql)
+* [Pact with GraphQL](https://github.com/pact-foundation/pact-js/tree/master/examples/graphql)
 * [Pact with Karma + Jasmine](https://github.com/pact-foundation/pact-js/tree/master/karma/jasmine)
 * [Pact with Karma + Mocha](https://github.com/pact-foundation/pact-js/tree/master/karma/mocha)
 
 ### Asynchronous APIs
 
-* [Asynchronous messages](https://github.com/pact-foundation/pact-js/tree/feat/message-pact/examples/messages)
-* [Serverless](https://github.com/pact-foundation/pact-js/tree/feat/message-pact/examples/serverless)
+* [Asynchronous messages](https://github.com/pact-foundation/pact-js/tree/master/examples/messages)
+* [Serverless](https://github.com/pact-foundation/pact-js/tree/master/examples/serverless)
 
 ## Using Pact in non-Node environments
 

--- a/examples/messages/README.md
+++ b/examples/messages/README.md
@@ -32,7 +32,7 @@ From a Pact testing point of view, Pact takes the place of the intermediary (MQ/
 The following test creates a contract for a Dog API handler:
 
 ```js
-  const { MessageConsumer, Message, synchronousBodyHandler } = require("@pact-foundation/pact");
+  const { MessageConsumerPact, Message, synchronousBodyHandler } = require("@pact-foundation/pact");
 
   // 1 Dog API Handler
   const dogApiHandler = function(dog) {
@@ -46,7 +46,7 @@ The following test creates a contract for a Dog API handler:
   }
 
   // 2 Pact Message Consumer
-  const messagePact = new MessageConsumer({
+  const messagePact = new MessageConsumerPact({
     consumer: "MyJSMessageConsumer",
     dir: path.resolve(process.cwd(), "pacts"),
     pactfileWriteMode: "update",
@@ -94,7 +94,7 @@ A Provider (Producer in messaging parlance) is the system that will be putting a
 As per the Consumer case, Pact takes the position of the intermediary (MQ/broker) and checks to see whether or not the Provider sends a message that matches the Consumer's expectations.
 
 ```js
-const { MessageProvider, Message } = require("@pact-foundation/pact");
+const { MessageProviderPact, Message } = require("@pact-foundation/pact");
 
 // 1 Messaging integration client
 const dogApiClient = {
@@ -112,8 +112,8 @@ const dogApiClient = {
 describe("Message provider tests", () => {
 
   // 2 Pact setup
-  const p = new MessageProvider({
-    handlers: {
+  const p = new MessageProviderPact({
+    messageProviders: {
       "a request for a dog": () => dogApiClient.createDog(),
     },
     provider: "MyJSMessageProvider",


### PR DESCRIPTION
These seem to date from before 6.0.0.

There are still some references to that branch in `.travis.yml` but I don't know what to do with them.
Also, I have not verified that every option in the fixed example README are still valid either, this is just the minimum changes I needed to apply to get my code to work.