### PR TITLE
fix(matchers): remove hardcoded true value from a boolean matcher

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -442,6 +442,15 @@ describe("Matcher", () => {
     describe("when used it should create a JSON object", () => {
       it("should not fail", () => {
         expect(boolean()).to.be.an("object")
+        expect(boolean().contents).to.equal(true)
+      })
+      it("should not fail with value=false", () => {
+        expect(boolean(false)).to.be.an("object")
+        expect(boolean(false).contents).to.equal(false)
+      })
+      it("should not fail with value=true", () => {
+        expect(boolean(true)).to.be.an("object")
+        expect(boolean(true).contents).to.equal(true)
       })
     })
   })

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -248,8 +248,8 @@ export function integer(int?: number) {
 /**
  * Boolean Matcher.
  */
-export function boolean() {
-  return somethingLike<boolean>(true)
+export function boolean(value: boolean = true) {
+  return somethingLike<boolean>(value)
 }
 
 // Convenience alias'


### PR DESCRIPTION
Currently, a value passed as an argument to `boolean()` matcher is ignored, and the value that is returned by mockserver is always `true`.
This PR to fixes this:
- `boolean()`, `boolean(true)` -> `true`
- `boolean(false)`, -> `false`