### PR TITLE
fix(verifier): do not ignore providerStateSetupUrl passed to Verifier constructor 

### DIFF
--- a/src/dsl/verifier.ts
+++ b/src/dsl/verifier.ts
@@ -106,13 +106,11 @@ export class Verifier {
   private runProviderVerification() {
     return (server: http.Server) => {
       const opts = {
+        providerStatesSetupUrl: `${this.address}:${server.address().port}${
+          this.stateSetupPath
+        }`,
         ...omit(this.config, "handlers"),
-        ...{ providerBaseUrl: `${this.address}:${server.address().port}` },
-        ...{
-          providerStatesSetupUrl: `${this.address}:${server.address().port}${
-            this.stateSetupPath
-          }`,
-        },
+        providerBaseUrl: `${this.address}:${server.address().port}`,
       } as PactNodeVerifierOptions
 
       return qToPromise<any>(pact.verifyPacts(opts))


### PR DESCRIPTION
Currently, `providerStateSetupUrl` passed to `Verifier` constructor is always ignored, as `opts.providerStateSetupUrl` always overrides it. `providerStateSetupUrl` was deprecated in v8, but I still expect that it should to be possible to set it. 
This allows us to upgrade pact to v8 on our side without a full re-write of our custom provider state handling logic (as v7 is not maintained anymore).

This PR fixes described issue, so:
`providerStateSetupUrl` setting passed to Verifier constructor takes precedence over internal proxy server's `providerStateSetupUrl`.
