### PR TITLE
chore(deps): Move @types/* to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,6 @@
   "homepage": "http://docs.pact.io/documentation/javascript.html",
   "dependencies": {
     "@pact-foundation/pact-node": "^8.6.0",
-    "@types/express": "^4.11.1",
-    "@types/bluebird": "^3.5.20",
-    "@types/bunyan": "^1.8.3",
     "bluebird": "~3.5.1",
     "body-parser": "^1.18.2",
     "bunyan": "^1.8.12",
@@ -102,9 +99,12 @@
   },
   "devDependencies": {
     "@pact-foundation/karma-pact": "~2.1.9",
+    "@types/bluebird": "^3.5.20",
+    "@types/bunyan": "^1.8.3",
     "@types/chai": "^4.0.3",
     "@types/chai-as-promised": "0.0.31",
     "@types/cli-color": "^0.3.29",
+    "@types/express": "^4.11.1",
     "@types/form-data": "^2.2.1",
     "@types/lodash": "^4.14.73",
     "@types/lodash.isnil": "^4.0.3",


### PR DESCRIPTION
@types/* packages should be in devDependencies instead of runtime dependencies.