### PR TITLE
Automatically set `changeOrigin: true` for non-local verifications 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "10"
 os:
   - linux
+sudo: required
 matrix:
   fast_finish: true
 cache: npm
@@ -20,7 +21,7 @@ script: ./scripts/build.sh
 after_success:
   - npm run coverage
 before_install:
-  - sysctl -w net.ipv6.conf.all.disable_ipv6=0
+  - sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
 before_deploy:
   - npm prune --production
   - tar -czvf pactjs.tar.gz config dist src package.json README.md LICENSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
 script: ./scripts/build.sh
 after_success:
   - npm run coverage
+before_install:
+  - sysctl net.ipv6.conf.all.disable_ipv6=
 before_deploy:
   - npm prune --production
   - tar -czvf pactjs.tar.gz config dist src package.json README.md LICENSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: ./scripts/build.sh
 after_success:
   - npm run coverage
 before_install:
-  - sysctl net.ipv6.conf.all.disable_ipv6=
+  - sysctl -w net.ipv6.conf.all.disable_ipv6=0
 before_deploy:
   - npm prune --production
   - tar -czvf pactjs.tar.gz config dist src package.json README.md LICENSE

--- a/src/common/net.ts
+++ b/src/common/net.ts
@@ -7,12 +7,12 @@
 import * as net from "net"
 import { Promise as bluebird } from "bluebird"
 
+export const localAddresses = ["127.0.0.1", "localhost", "0.0.0.0", "::1"]
+
 const isPortAvailable = (port: number, host: string): Promise<void> =>
   Promise.resolve(
     bluebird
-      .each([host, "127.0.0.1", "localhost", "0.0.0.0"], h =>
-        portCheck(port, h)
-      )
+      .each([host, ...localAddresses], h => portCheck(port, h))
       .then(() => Promise.resolve(undefined))
       .catch(e => Promise.reject(e))
   )

--- a/src/dsl/verifier.ts
+++ b/src/dsl/verifier.ts
@@ -12,6 +12,8 @@ import * as http from "http"
 import logger from "../common/logger"
 import { LogLevel } from "./options"
 import ConfigurationError from "../errors/configurationError"
+import { localAddresses } from "../common/net"
+import * as url from "url"
 const HttpProxy = require("http-proxy")
 const bodyParser = require("body-parser")
 
@@ -198,6 +200,11 @@ export class Verifier {
   private setConfig(config: VerifierOptions) {
     this.config = config
 
+    if (this.config.logLevel && !isEmpty(this.config.logLevel)) {
+      serviceFactory.logLevel(this.config.logLevel)
+      logger.level(this.config.logLevel)
+    }
+
     this.deprecatedFields.forEach(f => {
       if ((this.config as any)[f]) {
         logger.warn(
@@ -209,13 +216,23 @@ export class Verifier {
     if (this.config.validateSSL === undefined) {
       this.config.validateSSL = true
     }
+
     if (this.config.changeOrigin === undefined) {
       this.config.changeOrigin = false
-    }
 
-    if (this.config.logLevel && !isEmpty(this.config.logLevel)) {
-      serviceFactory.logLevel(this.config.logLevel)
-      logger.level(this.config.logLevel)
+      if (!this.isLocalVerification()) {
+        this.config.changeOrigin = true
+        logger.debug(
+          `non-local provider address ${this.config.providerBaseUrl} detected, setting 'changeOrigin' to 'true'. This property can be overridden.`
+        )
+      }
     }
+  }
+
+  private isLocalVerification() {
+    const u = new url.URL(this.config.providerBaseUrl)
+    return (
+      localAddresses.includes(u.host) || localAddresses.includes(u.hostname)
+    )
   }
 }


### PR DESCRIPTION
When the provider verification process is run against a remote provider, the origin
header can mismatch the actual remote proxied API.

This PR defaults to change the origin of the host header to the target URL in this case only, unless
specifically overridden by the user. This should remove a class of confusing issues
for new users.

See #280, #281 and #282 for background. This specific issue has come up on Slack
a number of times, and hence fixing before it appears as a GH issue.