### PR TITLE
chore(config): TypeScript Example - mocha.opts removing --compilers since it is depreciated

### DIFF
--- a/examples/graphql/mocha.opts
+++ b/examples/graphql/mocha.opts
@@ -1,6 +1,6 @@
 --bail
---require ./test/helper.ts
 --require ts-node/register
+--require ./test/helper.ts
 --require source-map-support/register
 --full-trace
 --reporter spec

--- a/examples/typescript/test/mocha.opts
+++ b/examples/typescript/test/mocha.opts
@@ -1,7 +1,6 @@
 --bail
---compilers ts:ts-node/register
---require ./test/helper.ts
 --require ts-node/register
+--require ./test/helper.ts
 --require source-map-support/register
 --full-trace
 --reporter spec

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,6 @@
 --bail
---require ./test/helper.ts
 --require ts-node/register
+--require ./test/helper.ts
 --require source-map-support/register
 --full-trace
 --reporter spec


### PR DESCRIPTION
Mocha Maintainance - removed deprecation warning (--compilers)
https://github.com/mochajs/mocha/wiki/compilers-deprecation

This is a was of [PR 339](https://github.com/pact-foundation/pact-js/pull/339) but PR399 currently fails on older node versions.  