### PR TITLE
Address deprecation warnings for verifyProvider()

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ let opts = {
   ...
 };
 
-new Verifier().verifyProvider(opts).then(function () {
+new Verifier(opts).verifyProvider().then(function () {
 	// do something
 });
 ```

--- a/examples/e2e/test/provider.spec.js
+++ b/examples/e2e/test/provider.spec.js
@@ -74,7 +74,7 @@ describe("Pact Verification", () => {
       providerVersion: "1.0.0",
     }
 
-    return new Verifier().verifyProvider(opts).then(output => {
+    return new Verifier(opts).verifyProvider().then(output => {
       console.log("Pact Verification Complete!")
       console.log(output)
     })

--- a/examples/graphql/provider.spec.ts
+++ b/examples/graphql/provider.spec.ts
@@ -26,7 +26,7 @@ describe("Pact Verification", () => {
       tags: ["prod"],
     }
 
-    return new Verifier().verifyProvider(opts).then(output => {
+    return new Verifier(opts).verifyProvider().then(output => {
       server.close()
     })
   })


### PR DESCRIPTION
The examples & readme were giving we deprecation warnings (although they still worked) for their usage of `verifyProvider(opts)`.

This PR is simply updating the readme & the relevant examples to not show the warning anymore.