### PR TITLE
fix(graph-ql): Allow withOperation to accept null

### DIFF
--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -25,7 +25,7 @@ export class GraphQLInteraction extends Interaction {
   /**
    * The type of GraphQL operation. Generally not required.
    */
-  public withOperation(operation: string) {
+  public withOperation(operation: string | null) {
     this.operation = operation
 
     return this


### PR DESCRIPTION
Issue:
I am using apollo client with http link. I am not adding any operation name in the query/mutation so operation name is passed as null in the payload.  
In the graph ql interaction, I can not pass operation name null as it only accepts string ( withOperation(operation: string): this;) while it is defined as  protected operation?: string | null;


Change: Can we allow operation name to accept null?


**Consumer:**
```
export function createTrust(): any {
  return client
    .mutate({
      mutation: gql`
        mutation {
          createTrust {
            id
          }
        }
      `,
      variables: {
        Authorization: MOCK_AUTH_HEADER
      }
    })
    .then((result: any) => result.data)
}
```


**Interaction:**
```
export const createTrustMutaion = new GraphQLInteraction()
  .uponReceiving('a create trust request')
  .withQuery(
    `
    mutation {
      createTrust {
        id
      }
    }
    `
  )
  .withRequest({
    path: '/graphql',
    method: 'POST'
  })
  .withVariables({
    Authorization: MOCK_AUTH_HEADER
  })
  .willRespondWith({
    status: 200,
    headers: {
      'Content-Type': 'application/json'
    },
    body: like(testTrust)
  })
```
Here if I add `withOperation(null)`, typescript compiler complains as the field only accepts string.




