### PR TITLE
fix(example): Fixed missing coverage statistics by adding nyc section to package.json

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -8,6 +8,25 @@
   },
   "author": "",
   "license": "MIT",
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "**/*.ts"
+    ],
+    "exclude": [
+      "**/*.d.ts"
+    ],
+    "reporter": [
+      "html"
+    ],
+    "all": true,
+    "branches": 80,
+    "lines": 80,
+    "functions": 80,
+    "statements": 80
+  },
   "devDependencies": {
     "@pact-foundation/pact": "^8.2.6",
     "@types/chai": "^4.0.3",


### PR DESCRIPTION
When running the test for the typescript example, it is missing the Coverage statistics:

```
=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
```

This was due to missing a [nuc config section](https://www.npmjs.com/package/nyc#common-configuration-options) in the package.json

This is now fixed

```
=============================== Coverage summary ===============================
Statements   : 88.89% ( 48/54 )
Branches     : 100% ( 0/0 )
Functions    : 84.21% ( 16/19 )
Lines        : 88.24% ( 45/51 )
================================================================================
```
 