### PR TITLE
Run contract tests using Jasmine

### DIFF
--- a/examples/karma/package.json
+++ b/examples/karma/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:mocha && npm run test:jasmine",
     "test:mocha": "karma start ./mocha/karma.conf.js",
-    "test:jasmine": "karma start ./mocha/karma.conf.js"
+    "test:jasmine": "karma start ./jasmine/karma.conf.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
The command to run contract tests using Jasmine  `test:jasmine` was running test with mocha instead of jasmine