### PR TITLE
fix(matcher): Update isMatcher to correctly check null values

### DIFF
--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -270,7 +270,7 @@ export interface MatcherResult {
 }
 
 export function isMatcher(x: MatcherResult | any): x is MatcherResult {
-  return (x as MatcherResult).getValue !== undefined
+  return x != null && (x as MatcherResult).getValue !== undefined
 }
 
 // Recurse the object removing any underlying matching guff, returning


### PR DESCRIPTION
This is needed for `extractPayload` to work on objects with fields with `null` values.