### PR TITLE
fix(net): stop port check from failing due to ipv6 unavailability (#381)

### DIFF
--- a/src/common/net.spec.ts
+++ b/src/common/net.spec.ts
@@ -9,34 +9,79 @@ chai.use(chaiAsPromised)
 
 describe("Net", () => {
   const port = 4567
-  const host = "0.0.0.0"
+  const defaultHost = "0.0.0.0"
   const specialPort = process.platform.match("win") ? -1 : 80
 
   describe("#isPortAvailable", () => {
     context("when the port is not allowed to be bound", () => {
       it("returns a rejected promise", () => {
-        return expect(isPortAvailable(specialPort, host)).to.eventually.be
-          .rejected
+        return expect(isPortAvailable(specialPort, defaultHost)).to.eventually
+          .be.rejected
       })
     })
 
     context("when the port is available", () => {
       it("returns a fulfilled promise", () => {
-        return expect(isPortAvailable(port, host)).to.eventually.be.fulfilled
+        return expect(isPortAvailable(port, defaultHost)).to.eventually.be
+          .fulfilled
       })
     })
 
     context("when the port is unavailable", () => {
-      it("returns a rejected promise", () => {
-        createServer(port).then((_: { close(): any }) => {
-          return expect(isPortAvailable(port, host)).to.eventually.be.rejected
-        })
-      })
+      let closeFn = (cb: any) => cb()
+
+      it("returns a rejected promise", () =>
+        createServer(port).then((server: { close(): any }) => {
+          closeFn = server.close.bind(server)
+          return expect(isPortAvailable(port, defaultHost)).to.eventually.be
+            .rejected
+        }))
+
+      // close the servers used in this test as to not conflict with other tests
+      afterEach(done => closeFn(done))
+    })
+
+    // this test uses the test port on all ipv4 and ipv6 hosts via the respective broadcast
+    // addresses (0.0.0.0 and ::)
+    context("when the no local hosts are available", () => {
+      let closeIpV4ServerFn = (cb: any) => cb()
+      let closeIpV6ServerFn = (cb: any) => cb()
+
+      it("return a rejected promise", () =>
+        createServer(port, defaultHost).then((ipv4Server: { close(): any }) => {
+          closeIpV4ServerFn = ipv4Server.close.bind(ipv4Server)
+
+          return createServer(port, "::").then(
+            (ipv6Server: { close(): any }) => {
+              closeIpV6ServerFn = ipv6Server.close.bind(ipv6Server)
+              return expect(isPortAvailable(port, "127.0.0.1")).to.eventually.be
+                .rejected
+            }
+          )
+        }))
+
+      // close the servers used in this test as to not conflict with other tests
+      afterEach(done => closeIpV4ServerFn(() => closeIpV6ServerFn(done)))
+    })
+
+    context("when a single host is unavailable", () => {
+      let closeFn = (cb: any) => cb()
+
+      it("return a fulfilled promise", () =>
+        // simulate ::1 being unavailable
+        createServer(port, "::1").then((server: { close(): any }) => {
+          closeFn = server.close.bind(server)
+          // this should work as the `127.0.0.1` is NOT `::1`
+          expect(isPortAvailable(port, "127.0.0.1")).to.eventually.be.fulfilled
+        }))
+
+      // close the servers used in this test as to not conflict with other tests
+      afterEach(done => closeFn(done))
     })
   })
 
   // Utility function to create a server on a given port and return a Promise
-  const createServer = (p: number) =>
+  const createServer = (p: number, host = defaultHost) =>
     new Promise((resolve, reject) => {
       const nodeNet = require("net")
       const server = nodeNet.createServer()
@@ -44,8 +89,8 @@ describe("Net", () => {
       server.on("error", (err: any) => reject(err))
       server.on("listening", () => resolve(server))
 
-      server.listen(p, host, () => {
-        logger.info(`test server is up on port ${p}`)
+      server.listen({ port: p, host, exclusive: true, ipv6Only: true }, () => {
+        logger.info(`test server is up on ${host}:${p}`)
       })
     })
 })

--- a/src/common/net.ts
+++ b/src/common/net.ts
@@ -38,7 +38,7 @@ const portCheck = (port: number, host: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     const server: any = net
       .createServer()
-      .listen({ port, host, exclusive: true, ipv6Only: true })
+      .listen({ port, host, exclusive: true })
       .on("error", (e: any) => {
         if (e.code === "EADDRINUSE") {
           reject(new Error(`Port ${port} is unavailable on address ${host}`))

--- a/src/common/net.ts
+++ b/src/common/net.ts
@@ -9,19 +9,36 @@ import { Promise as bluebird } from "bluebird"
 
 export const localAddresses = ["127.0.0.1", "localhost", "0.0.0.0", "::1"]
 
-const isPortAvailable = (port: number, host: string): Promise<void> =>
-  Promise.resolve(
+const isPortAvailable = (port: number, host: string): Promise<void> => {
+  return Promise.resolve(
     bluebird
-      .each([host, ...localAddresses], h => portCheck(port, h))
-      .then(() => Promise.resolve(undefined))
-      .catch(e => Promise.reject(e))
+      .map(
+        localAddresses,
+        // we meed to wrap the built-in Promise with bluebird.reflect() so we can
+        // test the result of the promise without failing bluebird.map()
+        h => bluebird.resolve(portCheck(port, h)).reflect(),
+        // do each port check sequentially (as localhost & 127.0.0.1 will conflict on most default environments)
+        { concurrency: 1 }
+      )
+      .then(inspections => {
+        // if every port check failed, then fail the `isPortAvailable` check
+        if (inspections.every(inspection => !inspection.isFulfilled())) {
+          return Promise.reject(
+            new Error(`Cannot open port ${port} on ipv4 or ipv6 interfaces`)
+          )
+        }
+
+        // the local addresses passed - now check the host that the user has specified
+        return portCheck(port, host)
+      })
   )
+}
 
 const portCheck = (port: number, host: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     const server: any = net
       .createServer()
-      .listen({ port, host, exclusive: true })
+      .listen({ port, host, exclusive: true, ipv6Only: true })
       .on("error", (e: any) => {
         if (e.code === "EADDRINUSE") {
           reject(new Error(`Port ${port} is unavailable on address ${host}`))


### PR DESCRIPTION
As discussed in issue #381, 

> We could warn if one of the interfaces is not available but others are, and fail if all promises reject (i.e. all checks fail).

---

The code that calls the `close` functions on the server instances used in testing isn't the cleanest approach - more than happy to take on feedback (which also applies to the whole PR).