### PR TITLE
chore(examples): update Jest Example

### DIFF
--- a/examples/jest/__tests__/index.spec.js
+++ b/examples/jest/__tests__/index.spec.js
@@ -35,7 +35,7 @@ describe("Dog's API", () => {
     })
 
     // add expectations
-    it("returns a sucessful body", done => {
+    it("returns a sucessful body", () => {
       return getMeDogs({
         url,
         port,
@@ -44,7 +44,6 @@ describe("Dog's API", () => {
           expect(response.headers["content-type"]).toEqual("application/json")
           expect(response.data).toEqual(EXPECTED_BODY)
           expect(response.status).toEqual(200)
-          done()
         })
         .then(() => provider.verify())
     })

--- a/examples/jest/__tests__/multipleSpecs.spec.js
+++ b/examples/jest/__tests__/multipleSpecs.spec.js
@@ -39,7 +39,7 @@ describe("Dog's API", () => {
     })
 
     // add expectations
-    it("returns a sucessful body", done => {
+    it("returns a sucessful body", () => {
       return getMeDogs({
         url,
         port,
@@ -47,7 +47,6 @@ describe("Dog's API", () => {
         expect(response.headers["content-type"]).toEqual("application/json")
         expect(response.data).toEqual(EXPECTED_BODY)
         expect(response.status).toEqual(200)
-        done()
       })
     })
   })
@@ -76,7 +75,7 @@ describe("Dog's API", () => {
     })
 
     // add expectations
-    it("returns a sucessful body", done => {
+    it("returns a sucessful body", () => {
       return getMeDogs({
         url,
         port,
@@ -84,7 +83,6 @@ describe("Dog's API", () => {
         expect(response.headers["content-type"]).toEqual("application/json")
         expect(response.data).toEqual(EXPECTED_BODY)
         expect(response.status).toEqual(200)
-        done()
       })
     })
   })

--- a/examples/jest/pactTestWrapper.js
+++ b/examples/jest/pactTestWrapper.js
@@ -1,9 +1,5 @@
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000
 
-beforeAll(done => {
-  provider.setup().then(() => done())
-})
+beforeAll(() => provider.setup())
 
-afterAll(done => {
-  provider.finalize().then(() => done())
-})
+afterAll(() => provider.finalize())

--- a/examples/jest/publish.js
+++ b/examples/jest/publish.js
@@ -10,4 +10,4 @@ let opts = {
   consumerVersion: "2.0.0",
 }
 
-publisher.publishPacts(opts).then(() => done())
+publisher.publishPacts(opts)


### PR DESCRIPTION
Remove unnecessary done callbacks in async tests since Jest resolves the promises when they are
returned.