### PR TITLE
Eliminate memory leak in logger for jest

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -3,7 +3,14 @@ const PrettyStream = require("bunyan-prettystream")
 const pkg = require("./metadata")
 
 const prettyStdOut = new PrettyStream()
-prettyStdOut.pipe(process.stdout)
+
+prettyStdOut.on("data", (data: string) => {
+  process.stdout.write(data)
+})
+
+prettyStdOut.on("error", (e: Error) => {
+  process.stdout.write(e.toString())
+})
 
 export class Logger extends bunyan {
   public time(action: string, startTime: number) {


### PR DESCRIPTION
Related to #397

`.pipe()` call attaches events listeners to the writeable stream
which in case of stdout and sequential jest tests causes memory
leak as those listeners are added for every test file.

Since stdout stream is special, for example it never ends while
the process is runing, we can use simplified piping by
listening to the `data` event of the readable stream and
redirect data to stdout. This way no listeners are leaking.