### PR TITLE
feature: Support state params coming from stateHandlers (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,11 @@ let opts = {
     "Has an animal with ID 1": () => {
       importData()
       return Promise.resolve(`Animals added to the db`)
+    },
+    "Has a newly created animal": () => {
+      return createData().then(animal => ({
+        id: animal.id
+      }));
     }
   }
 }

--- a/src/dsl/verifier.ts
+++ b/src/dsl/verifier.ts
@@ -18,6 +18,7 @@ const HttpProxy = require("http-proxy")
 const bodyParser = require("body-parser")
 
 export interface ProviderState {
+  state?: string
   states?: [string]
 }
 
@@ -92,7 +93,7 @@ export class Verifier {
       const opts = {
         providerStatesSetupUrl: `${this.address}:${server.address().port}${
           this.stateSetupPath
-        }`,
+          }`,
         ...omit(this.config, "handlers"),
         providerBaseUrl: `${this.address}:${server.address().port}`,
       }
@@ -153,7 +154,12 @@ export class Verifier {
       const message: ProviderState = req.body
 
       return this.setupStates(message)
-        .then(() => res.sendStatus(200))
+        .then((params) => res.status(200).json({
+          state: message.state,
+          params: {
+            ...params.filter((returnParam: any) => typeof returnParam === 'object')
+          }
+        }))
         .catch(e => res.status(500).send(e))
     }
   }


### PR DESCRIPTION
I am testing a Pact implementation to our infrastructure, however I am having some issues with the JS version of library.

While Java version [has the implementation already](https://github.com/DiUS/pact-jvm/tree/master/consumer/pact-jvm-consumer-junit#having-values-injected-from-provider-state-callbacks-3611), I can't inject any parameters from `stateHandlers`. 

This PR allows pact-js to pass those parameters to **pact-provider-verifier** which should later on inject them to my pact files downloaded from a broker. While I thought this will fix things, **pact-provider-verifier** still doesn't support this use case.

Issue to discuss this generator here: https://github.com/pact-foundation/pact-provider-verifier/issues/49

