### PR TITLE
fix: Need to initialise the data otherwise the server is going to load empty

### DIFF
--- a/examples/e2e/test/provider.spec.js
+++ b/examples/e2e/test/provider.spec.js
@@ -6,6 +6,7 @@ const { server, importData, animalRepository } = require("../provider.js")
 const path = require("path")
 
 server.listen(8081, () => {
+  importData()
   console.log("Animal Profile Service listening on http://localhost:8081")
 })
 


### PR DESCRIPTION
I was running these tests and noticed that when running the `npm run test:provider` the server was always empty and not able to create the data, this is because we need to importData() before running the server on the provider spec. Otherwise the server is going to be always empty.

