### PR TITLE
feat: remove need for pact-node in almost all uses, including examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ TL;DR - you almost always want Pact JS.
 | Node.js                   | Pact JS   |                                                                                                                     |
 | Browser testing           | Pact Web  | You probably still want Pact JS. See [Using Pact in non-Node environments](#using-pact-in-non-node-environments) \* |
 | Isomorphic testing        | Pact Web  | You probably still want Pact JS. See [Using Pact in non-Node environments](#using-pact-in-non-node-environments) \* |
-| Publishing to Pact Broker | Pact Node | Included in Pact JS distribution                                                                                    |
+| Publishing to Pact Broker | Pact JS |          |
 
 \* The "I need to run it in the browser" question comes up occasionally. The question is this - for your JS code to be able to make a call to another API, is this dependent on browser-specific code? In most cases, people use tools like React/Angular which have libraries that work on the server and client side, in which case, these tests don't need to run in a browser and could instead be executed in a Node.js environment.
 
@@ -478,7 +478,7 @@ _Important Note_: You should only use this feature for things that can not be pe
 
 ### Publishing Pacts to a Broker
 
-Sharing is caring - to simplify sharing Pacts between Consumers and Providers, we have created the [Pact Broker](https://pact.dius.com.au).
+Sharing is caring - to simplify sharing Pacts between Consumers and Providers, we have created the [Pact Broker](https://pactflow.io).
 
 The Broker:
 
@@ -490,17 +490,19 @@ The Broker:
 - integrates with other systems, such as Slack or your CI server, via webhooks
 - ...and much much [more](https://docs.pact.io/getting_started/sharing_pacts).
 
-[Host your own](https://github.com/pact-foundation/pact_broker), or signup for a free hosted [Pact Broker](https://pact.dius.com.au).
+[Host your own](https://github.com/pact-foundation/pact_broker), or signup for a free hosted [Pact Broker](https://pactflow.io).
 
 ```js
-let pact = require('@pact-foundation/pact-node');
-let opts = {
+const { Publisher } = require("@pact-foundation/pact")
+const opts = {
    ...
 };
 
-pact.publishPacts(opts).then(function () {
-	// do something
-});
+new Publisher(opts)
+  .publishPacts()
+  .then(() => {
+    // ...
+  })
 ```
 
 #### Pact publishing options
@@ -524,7 +526,7 @@ If your broker has a self signed certificate, set the environment variable `SSL_
 
 #### Publishing Verification Results to a Pact Broker
 
-If you're using a Pact Broker (e.g. a hosted one at https://pact.dius.com.au), you can
+If you're using a Pact Broker (e.g. a hosted one at https://pactflow.io), you can
 publish your verification results so that consumers can query if they are safe
 to release.
 

--- a/examples/e2e/test/consumer.spec.js
+++ b/examples/e2e/test/consumer.spec.js
@@ -3,6 +3,7 @@ const chai = require("chai")
 const chaiAsPromised = require("chai-as-promised")
 const expect = chai.expect
 const { Pact, Matchers } = require("@pact-foundation/pact")
+const pact = require("@pact-foundation/pact")
 const LOG_LEVEL = process.env.LOG_LEVEL || "WARN"
 
 chai.use(chaiAsPromised)

--- a/examples/e2e/test/publish.js
+++ b/examples/e2e/test/publish.js
@@ -1,4 +1,4 @@
-const pact = require("@pact-foundation/pact-node")
+const { Publisher } = require("@pact-foundation/pact")
 const path = require("path")
 const opts = {
   pactFilesOrDirs: [
@@ -18,8 +18,8 @@ const opts = {
       : Math.floor(new Date() / 1000)),
 }
 
-pact
-  .publishPacts(opts)
+new Publisher(opts)
+  .publishPacts()
   .then(() => {
     console.log("Pact contract publishing complete!")
     console.log("")

--- a/examples/graphql/publish.js
+++ b/examples/graphql/publish.js
@@ -1,4 +1,4 @@
-const pact = require("@pact-foundation/pact-node")
+const { Publisher } = require("@pact-foundation/pact")
 const path = require("path")
 const opts = {
   pactFilesOrDirs: [
@@ -15,8 +15,8 @@ const opts = {
       : Math.floor(new Date() / 1000)),
 }
 
-pact
-  .publishPacts(opts)
+new Publisher(opts)
+  .publishPacts()
   .then(() => {
     console.log("Pact contract publishing complete!")
     console.log("")

--- a/examples/jest/publish.js
+++ b/examples/jest/publish.js
@@ -1,4 +1,4 @@
-let publisher = require("@pact-foundation/pact-node")
+let { Publisher } = require("@pact-foundation/pact")
 let path = require("path")
 
 let opts = {
@@ -9,4 +9,4 @@ let opts = {
   consumerVersion: "2.0.0",
 }
 
-publisher.publishPacts(opts)
+new Publisher(opts).publishPacts()

--- a/examples/messages/publish.js
+++ b/examples/messages/publish.js
@@ -1,4 +1,4 @@
-const pact = require("@pact-foundation/pact-node")
+const { Publisher } = require("@pact-foundation/pact")
 const path = require("path")
 const opts = {
   pactFilesOrDirs: [
@@ -18,8 +18,8 @@ const opts = {
       : Math.floor(new Date() / 1000)),
 }
 
-pact
-  .publishPacts(opts)
+new Publisher(opts)
+  .publishPacts()
   .then(() => {
     console.log("Pact contract publishing complete!")
     console.log("")

--- a/examples/serverless/publish.js
+++ b/examples/serverless/publish.js
@@ -1,4 +1,4 @@
-const pact = require("@pact-foundation/pact-node")
+const { Publisher } = require("@pact-foundation/pact")
 const path = require("path")
 const opts = {
   pactFilesOrDirs: [path.resolve(__dirname, "pacts/")],
@@ -13,8 +13,8 @@ const opts = {
       : Math.floor(new Date() / 1000)),
 }
 
-pact
-  .publishPacts(opts)
+new Publisher(opts)
+  .publishPacts()
   .then(() => {
     console.log("Pact contract publishing complete!")
     console.log("")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "deploy:package": "tar -czf pactjs.tar.gz config dist src package.json README.md LICENSE",
     "deploy:prepare": "npm i --production && npm run deploy:package && ./scripts/create_npmrc_file.sh",
-    "dist": "npm run compile && webpack --config ./config/webpack.web.config.js",
+    "dist": "npm run compile && webpack --config ./config/webpack.web.config.js && cp package.json ./dist",
     "jscpd": "jscpd -p src -r json -o jscpd.json",
     "lint": "npm run lint:prettier:ts && npm run lint:prettier:js && tslint -c tslint.json '{src,test,examples}/**/*.ts' -e '**/node_modules/**/*.ts'",
     "lint:fix": "prettier --parser typescript --write \"{src,test,examples}/**/*.ts\" && prettier --write \"{src,test,examples}/**/*.js\"",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,8 @@ fi
 
 npm run dist
 
+${DIR}/prepare.sh
+
 # Link the build so that the examples are always testing the
 # current build, in it's properly exported format
 (cd dist && npm link)
@@ -19,11 +21,9 @@ for i in examples/*; do
   [ -e "$i" ] || continue # prevent failure if there are no examples
   echo "--> running tests for: $i"
   if [[ "$i" =~ "karma" ]]; then
-    echo "    linking pact-web"
-    (cd "$i" && npm link @pact-foundation/pact-web && npm it)
+    (cd "$i" && npm i && npm link @pact-foundation/pact-web && npm t)
   else
-    echo "    linking pact"
-    (cd "$i" && npm link @pact-foundation/pact && npm it)
+    (cd "$i" && npm i && npm link @pact-foundation/pact && npm t)
   fi
 done
 

--- a/src/dsl/publisher.spec.ts
+++ b/src/dsl/publisher.spec.ts
@@ -1,0 +1,21 @@
+/* tslint:disable:no-unused-expression no-empty no-string-literal*/
+import * as chai from "chai"
+import * as chaiAsPromised from "chai-as-promised"
+
+import { Publisher } from "./publisher"
+chai.use(chaiAsPromised)
+
+const expect = chai.expect
+
+describe("Publisher", () => {
+  describe("#constructor", () => {
+    it("constructs a valid Pubisher class", () => {
+      const p = new Publisher({
+        consumerVersion: "1.0.0",
+        pactBroker: "http://foo.com",
+        pactFilesOrDirs: [],
+      })
+      expect(p).to.have.nested.property("opts.consumerVersion")
+    })
+  })
+})

--- a/src/dsl/publisher.ts
+++ b/src/dsl/publisher.ts
@@ -1,0 +1,14 @@
+/**
+ * Pact Publisher service
+ * @module Publisher
+ */
+import { qToPromise } from "../common/utils"
+import publisher, { PublisherOptions } from "@pact-foundation/pact-node"
+
+export class Publisher {
+  constructor(private opts: PublisherOptions) {}
+
+  public publishPacts(): Promise<string[]> {
+    return qToPromise<string[]>(publisher.publishPacts(this.opts))
+  }
+}

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -74,3 +74,10 @@ export * from "./dsl/interaction"
  * @static
  */
 export * from "./dsl/mockService"
+
+/**
+ * Exposes {@link Publisher}
+ * @memberof Pact
+ * @static
+ */
+export * from "./dsl/publisher"


### PR DESCRIPTION
Creates a new interface that's a thin wrapper over `pact-node`, `Publisher`, that may be used to publish to the broker.

All examples and documentation now updated, to remove references to the project to avoid confusion.
