### PR TITLE
fix(dsl): Fix extractPayload so that it passes through object properties that are not matchers (fixes #454)

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -596,6 +596,54 @@ describe("Matcher", () => {
     })
 
     describe("#extractPayload", () => {
+      describe("when given an object with no matchers", () => {
+        const object = {
+          some: "data",
+          more: "strings",
+          an: ["array"],
+          someObject: {
+            withData: true,
+            withNumber: 1,
+          },
+        }
+
+        it("returns just that object", () => {
+          expect(extractPayload(object)).to.deep.eql(object)
+        })
+      })
+
+      describe("when given an object with some matchers", () => {
+        const someMatchers = {
+          some: somethingLike("data"),
+          more: "strings",
+          an: ["array"],
+          another: eachLike("this"),
+          someObject: {
+            withData: somethingLike(true),
+            withTerm: term({ generate: "this", matcher: "this|that" }),
+            withNumber: 1,
+            withAnotherNumber: somethingLike(2),
+          },
+        }
+
+        const expected = {
+          some: "data",
+          more: "strings",
+          an: ["array"],
+          another: ["this"],
+          someObject: {
+            withData: true,
+            withTerm: "this",
+            withNumber: 1,
+            withAnotherNumber: 2,
+          },
+        }
+
+        it("returns without matching guff", () => {
+          expect(extractPayload(someMatchers)).to.deep.eql(expected)
+        })
+      })
+
       describe("when given a simple matcher", () => {
         it("removes all matching guff", () => {
           const expected = "myawesomeword"

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -287,26 +287,23 @@ export function isMatcher(x: MatcherResult | any): x is MatcherResult {
 
 // Recurse the object removing any underlying matching guff, returning
 // the raw example content
-export function extractPayload(obj: any, stack: any = {}): any {
-  // special case: top level matching object
-  // we need to strip the properties
-  if (isMatcher(obj) && isEmpty(stack)) {
-    return extractPayload(obj.getValue(), obj.getValue())
+export function extractPayload(value: any): any {
+  if (isMatcher(value)) {
+    return extractPayload(value.getValue())
   }
 
-  // recurse the (remaining) object, replacing Matchers with their
-  // actual contents
-  for (const property in obj) {
-    if (obj.hasOwnProperty(property)) {
-      const value = obj[property]
-
-      if (isMatcher(value)) {
-        extractPayload(value.getValue(), (stack[property] = value.getValue()))
-      } else if (typeof value === "object") {
-        extractPayload(value, (stack[property] = value))
-      }
-    }
+  if (Object.prototype.toString.call(value) === "[object Array]") {
+    return value.map(extractPayload)
   }
 
-  return stack
+  if (typeof value === "object") {
+    return Object.keys(value).reduce(
+      (acc: object, propName: string) => ({
+        ...acc,
+        [propName]: extractPayload(value[propName]),
+      }),
+      {}
+    )
+  }
+  return value
 }


### PR DESCRIPTION
Fixes #454 by adding tests and changing the implementation of `extractPayload`.