### PR TITLE
Feat/v3.0.0 experiment with new API withMockServer

### DIFF
--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -2,7 +2,11 @@ const path = require("path")
 const chai = require("chai")
 const chaiAsPromised = require("chai-as-promised")
 const expect = chai.expect
-const { PactV3, MatchersV3 } = require("@pact-foundation/pact/v3")
+const {
+  PactV3,
+  MatchersV3,
+  withMockServer,
+} = require("@pact-foundation/pact/v3")
 const LOG_LEVEL = process.env.LOG_LEVEL || "WARN"
 
 chai.use(chaiAsPromised)
@@ -106,11 +110,11 @@ describe("Pact V3", () => {
       )
 
       it("returns a 401 unauthorized", () => {
-        return provider.executeTest(mockserver => {
+        return withMockServer(mockserver => {
           return expect(
             suggestion(suitor, () => mockserver.url)
           ).to.eventually.be.rejectedWith("Unauthorized")
-        })
+        }, provider)
       })
     })
     describe("and the user is authenticated", () => {
@@ -140,7 +144,7 @@ describe("Pact V3", () => {
         })
 
         it("returns a list of animals", () => {
-          return provider.executeTest(mockserver => {
+          return withMockServer(mockserver => {
             const suggestedMates = suggestion(suitor, () => mockserver.url)
             return Promise.all([
               expect(suggestedMates).to.eventually.have.deep.property(
@@ -151,7 +155,7 @@ describe("Pact V3", () => {
                 .to.eventually.have.property("suggestions")
                 .with.lengthOf(MIN_ANIMALS),
             ])
-          })
+          }, provider)
         })
       })
     })

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -142,11 +142,109 @@ export class PactV3 {
           return Promise.reject(new Error(error))
         })
         .finally(() => {
-          this.pact.shutdownTest(result)
+          this.pact.shutdownMockServer(result)
         })
     } else {
-      this.pact.shutdownTest(result)
+      this.pact.shutdownMockServer(result)
       return Promise.reject(result.testError)
     }
   }
+}
+
+interface RunningServer {
+  pact: PactV3
+  mockServer: V3MockServer
+}
+
+interface TestResult {
+  mockServerError: string | null;
+  mockServerMismatches: string[] | null;
+}
+
+export async function withMockServer<T>(
+  testFn: (...mockServers: V3MockServer[]) => Promise<T>,
+  ...pacts: PactV3[]
+): Promise<T> {
+  const runningServers: RunningServer[] = [];
+
+  try {
+    pacts.forEach(pact => {
+      runningServers.push({
+        pact,
+        mockServer: (pact as any).pact.startMockServer() as V3MockServer
+      });
+    });
+
+    const value = await testFn(...runningServers.map(({ mockServer }) => mockServer));
+
+    const pactErrors = getTestResults(runningServers).filter(isError);
+
+    if (pactErrors.length) {
+      let message = 'Mock server failed with the following mismatches: ';
+      for (const pactError of pactErrors) {
+        message += formatPactErrorMessage(pactError);
+      }
+      throw new Error(message);
+    }
+
+    runningServers.forEach(({ pact, mockServer}) => {
+      const nativePact = (pact as any).pact;
+      nativePact.writePactFile(mockServer.id, (pact as any).opts.dir);
+    });
+
+    return value;
+  } catch (err) {
+    const pactErrors = getTestResults(runningServers).filter(isError);
+
+    if (pactErrors.length) {
+      let message = "Test failed for the following reasons:";
+      message += "\n\n\tTest code failed with an error: " + err.message;
+
+      for (const pactError of pactErrors) {
+        message += formatPactErrorMessage(pactError);
+      }
+
+      const newError = new Error(message);
+      // 'Forward' original stack trace:
+      newError.stack = err.stack;
+      throw newError;
+    }
+
+    throw err;
+  } finally {
+    runningServers.forEach(({ pact, mockServer }) => {
+      (pact as any).pact.shutdownMockServer(mockServer);
+    });
+  }
+}
+
+function formatPactErrorMessage(testResult: TestResult): string {
+  let message = '';
+  if (testResult.mockServerError) {
+    message += '\n\n\t' + testResult.mockServerError;
+  }
+  if (testResult.mockServerMismatches) {
+    message += '\n\n\tMock server failed with the following mismatches: ';
+    let i = 1;
+    for (const mismatchJson of testResult.mockServerMismatches) {
+      let mismatches = JSON.parse(mismatchJson)
+      if (mismatches.mismatches) {
+        for (const mismatch of mismatches.mismatches) {
+          message += `\n\t\t${i++}) ${mismatch.type} ${
+            mismatch.path ? `(at ${mismatch.path}) ` : ""
+          }${mismatch.mismatch}`
+        }
+      }
+    }
+  }
+
+  return message;
+}
+
+function isError(testResult: TestResult): boolean {
+  return !!testResult.mockServerError || !!testResult.mockServerMismatches;
+}
+
+function getTestResults(runningServers: RunningServer[]): TestResult[] {
+  return runningServers.map(({ pact, mockServer }) => (pact as any).pact.getTestResult(mockServer.id));
 }


### PR DESCRIPTION
Hi again, some time ago I discussed with you guys on slack the use case of testing several endpoints together. I think the response was along the lines that code should be refactored so each endpoint can be tested in isolation. But let me give you a very real example of a popular programming pattern what would be near impossible to test: React+Apollo. Modern React code has no layers. The API call is performed right from the react component:

```
const MyComponent = () => {
  const response = useQuery('some graphql query', ...);

  return <react elements>;
}
```

There is nothing in the way of performing more than one query:

```
const MyComponent = () => {
  const response1 = useQuery('query 1', ...);
  const response2 = useQuery('query 2', ...);

  return <react elements>;
}
```

Therefore, I think that the current pact v3 API will be a little awkward to use for a lot of developers.

Here I've done an experiment with a new API, which allows (but IMHO does not encourage) running mock servers in parallel for the same test:

```
const provider1 = new PactV3(...);
const provider2 = new PactV3(...);

it('renders correctly', async () => {
  await withMockServer(async (mock1, mock2) => {
    // the test
  }, provider1, provider2);
})
```

I'm imagining this API replacing the `PactV3.executeTest` method. To be honest I wasn't very fond of this object oriented approach. It may appear that the Pact runs the mock server, but in reality that's not the case, it's the other way around: The framework starts a mock server and the mock server has a dependency to the pact. I think this new API better describes the architecture, and leaving the object oriented approach also enables running several mock servers.

This PR as of now is an experiment and is unfinished. I'm looking forward to your comments on the design.