### PR TITLE
fix: allow matcher as the top-level value of a query string

### DIFF
--- a/src/dsl/interaction.spec.ts
+++ b/src/dsl/interaction.spec.ts
@@ -145,6 +145,19 @@ describe("Interaction", () => {
       }
 
       it("is passed with matcher", () => {
+        request.query = term({
+          generate: "limit=50&status=finished&order=desc",
+          matcher: "^limit=[0-9]+&status=(finished)&order=(desc|asc)$",
+        })
+        expect(
+          new Interaction()
+            .uponReceiving("request")
+            .withRequest(request)
+            .json().request
+        ).to.have.any.keys("query")
+      })
+
+      it("is passed with matcher as the value", () => {
         request.query = {
           "id[]": eachLike("1"),
         }

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -151,6 +151,10 @@ export class Interaction {
    * @param query
    */
   private queryObjectIsValid(query: QueryObject) {
+    if (isMatcher(query)) {
+      return
+    }
+
     Object.values(query).every(value => {
       if (
         isMatcher(value) ||


### PR DESCRIPTION
Fixes #510