### PR TITLE
Feature: Support Pacts for verification

### DIFF
--- a/examples/v3/e2e/test/provider.spec.js
+++ b/examples/v3/e2e/test/provider.spec.js
@@ -14,7 +14,7 @@ describe("Pact Verification", () => {
   it("validates the expectations of Matching Service", () => {
     let token = "INVALID TOKEN"
 
-    let opts = {
+    return new VerifierV3({
       provider: "Animal Profile Service V3",
       providerBaseUrl: "http://localhost:8081",
 
@@ -75,7 +75,9 @@ describe("Pact Verification", () => {
         : "https://test.pact.dius.com.au",
 
       // Fetch from broker with given tags
-      tags: ["prod"],
+      consumerVersionTags: ["prod"],
+      providerVersionTags: ["master"],
+      enablePending: true,
 
       // Specific Remote pacts (doesn't need to be a broker)
       // pactUrls: ['https://test.pact.dius.com.au/pacts/provider/Animal%20Profile%20Service/consumer/Matching%20Service/latest'],
@@ -91,9 +93,7 @@ describe("Pact Verification", () => {
       pactBrokerPassword: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
       publishVerificationResult: true,
       providerVersion: "1.0.0",
-    }
-
-    return new VerifierV3(opts).verifyProvider().then(output => {
+    }).verifyProvider().then(output => {
       console.log("Pact Verification Complete!")
       console.log("Result:", output)
     })

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -18,7 +18,7 @@ neon-build = "0.5.1"
 neon = { version = "0.5.1", features = ["event-handler-api"] }
 pact_mock_server = "0.7.11"
 pact_mock_server_ffi = "0.0.11"
-pact_matching = "0.8.4"
+pact_matching = "0.8.5"
 pact_verifier = "0.9.4"
 env_logger = "0.7"
 log = "0.4.6"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -19,7 +19,7 @@ neon = { version = "0.5.1", features = ["event-handler-api"] }
 pact_mock_server = "0.7.11"
 pact_mock_server_ffi = "0.0.11"
 pact_matching = "0.8.4"
-pact_verifier = "0.9.3"
+pact_verifier = "0.9.4"
 env_logger = "0.7"
 log = "0.4.6"
 uuid = { version = "0.6", features = ["v4"] }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -38,7 +38,7 @@ lazy_static! {
 fn init(mut cx: FunctionContext) -> JsResult<JsString> {
     let mut builder = Builder::from_env("LOG_LEVEL");
     builder.target(Target::Stdout);
-    
+
     if let Ok(_) = builder.try_init() {
       debug!("Initialising Pact native library version {}", env!("CARGO_PKG_VERSION"));
     }
@@ -57,9 +57,9 @@ fn process_xml(body: String, matching_rules: &mut MatchingRuleCategory, generato
 }
 
 fn process_body(
-  body: String, 
-  content_type: Option<ContentType>, 
-  matching_rules: &mut MatchingRules, 
+  body: String,
+  content_type: Option<ContentType>,
+  matching_rules: &mut MatchingRules,
   generators: &mut Generators
 ) -> Result<OptionalBody, String> {
   let category = matching_rules.add_category("body");

--- a/native/src/verify.rs
+++ b/native/src/verify.rs
@@ -56,7 +56,7 @@ fn get_string_array(cx: &mut FunctionContext, obj: &JsObject, name: &str) -> Res
           Ok(tags)
         },
         Err(_) => if !items.is_a::<JsUndefined>() {
-          println!("    {}", Red.paint("ERROR: providerVersionTag must be a string or array of strings"));
+          println!("    {}", Red.paint(format!("ERROR: {} must be a string or array of strings", name)));
           Err(format!("{} must be a string or array of strings", name))
         } else {
           Ok(vec![])
@@ -293,32 +293,6 @@ impl Task for BackgroundTask {
     }
   }
 }
-
-// if let Some(values) = matches.values_of("broker-url") {
-//   sources.extend(values.map(|v| {
-//     if matches.is_present("user") || matches.is_present("token") {
-//       let name = matches.value_of("provider-name").unwrap().to_string();
-//       let pending = matches.is_present("enable-pending");
-//       let wip = matches.value_of("include-wip-pacts-since").map(|wip| wip.to_string());
-//       let consumer_version_tags = matches.values_of("consumer-version-tags")
-//         .map_or_else(|| vec![], |tags| consumer_tags_to_selectors(tags.collect::<Vec<_>>()));
-//       let provider_tags = matches.values_of("provider-tags")
-//         .map_or_else(|| vec![], |tags| tags.map(|tag| tag.to_string()).collect());
-
-//       if matches.is_present("token") {
-//         PactSource::BrokerWithDynamicConfiguration { provider_name: name, broker_url: s!(v), enable_pending: pending, include_wip_pacts_since: wip, provider_tags: provider_tags, selectors: consumer_version_tags,
-//           auth: matches.value_of("token").map(|token| HttpAuth::Token(token.to_string())), links: vec![] }
-//       } else {
-//       let auth = matches.value_of("user").map(|user| {
-//         HttpAuth::User(user.to_string(), matches.value_of("password").map(|p| p.to_string()))
-//       });
-//         PactSource::BrokerWithDynamicConfiguration { provider_name: name, broker_url: s!(v), enable_pending: pending, include_wip_pacts_since: wip, provider_tags: provider_tags, selectors: consumer_version_tags, auth: auth, links: vec![] }
-//       }
-//     } else {
-//       PactSource::BrokerUrl(s!(matches.value_of("provider-name").unwrap()), s!(v), None, vec![])
-//     }
-//   }).collect::<Vec<PactSource>>());
-// };
 
 fn consumer_tags_to_selectors(tags: Vec<String>) -> Vec<pact_verifier::ConsumerVersionSelector> {
   tags.iter().map(|t| {

--- a/src/v3/verifier.ts
+++ b/src/v3/verifier.ts
@@ -14,14 +14,30 @@ export interface VerifierV3Options {
   pactBrokerUsername?: string
   pactBrokerPassword?: string
   pactBrokerToken?: string
-  consumerVersionTag?: string | string[]
-  providerVersionTag?: string | string[]
-  customProviderHeaders?: string[]
+  // customProviderHeaders?: string[]
   publishVerificationResult?: boolean
   providerVersion?: string
-  tags?: string[]
   requestFilter?: (req: any) => any
   stateHandlers?: any
+
+  consumerVersionTags?: string | string[]
+  providerVersionTags?: string | string[]
+  // consumerVersionSelectors?: ConsumerVersionSelector[];
+  enablePending?: boolean
+  // timeout?: number;
+  // verbose?: boolean;
+  includeWipPactsSince?: string
+  // out?: string;
+  // logDir?: string;
+  // logLevel?: LogLevel;
+}
+
+export interface ConsumerVersionSelector {
+  pacticipant?: string
+  tag?: string
+  version?: string
+  latest?: boolean
+  all?: boolean
 }
 
 export class VerifierV3 {


### PR DESCRIPTION
Adds support for the "pacts for verification" endpoint, adding the following types to verifier:

* `consumerVersionTags?: string | string[]`
* `providerVersionTags?: string | string[]`
* `enablePending?: boolean`
* `includeWipPactsSince?: string`

NOTE: I added some commented out fields to the verifier to highlight areas we need to look at for compatibility with existing API, as a sort of "TODO" list.

BREAKING CHANGE: it's a breaking change to the API interface, but have pluralised the properties to be consistent with the current stable interface. Given this is an unstable release, I think it's OK.