### PR TITLE
fix: Expect at least one millisecond digit in iso8601DateTimeWithMillis

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -583,6 +583,12 @@ describe("Matcher", () => {
           expect(
             iso8601DateTimeWithMillis("2015-08-06T16:53:10.537357Z")
           ).to.be.an("object")
+          expect(
+            iso8601DateTimeWithMillis("2020-12-10T09:01:29.06Z")
+          ).to.be.an("object")
+          expect(
+            iso8601DateTimeWithMillis("2020-12-10T09:01:29.1Z")
+          ).to.be.an("object")
           expect(iso8601DateTimeWithMillis()).to.be.an("object")
         })
       })

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -16,7 +16,7 @@ export const ISO8601_DATE_FORMAT =
 export const ISO8601_DATETIME_FORMAT =
   "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$"
 export const ISO8601_DATETIME_WITH_MILLIS_FORMAT =
-  "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3,}([+-][0-2]\\d(:?[0-5]\\d)?|Z)$"
+  "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d(:?[0-5]\\d)?|Z)$"
 export const ISO8601_TIME_FORMAT =
   "^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$"
 export const RFC3339_TIMESTAMP_FORMAT =


### PR DESCRIPTION
This reflects how it's defined by ISO 8601.

Unfortunately, I can only find third-party references. I got to this, because I had a validation problem between a Typescript consumer and a JVM producer (with this matcher, of course):

```
Expected "2020-12-10T09:01:29.06Z" to match '^d{4}-[01]d-[0-3]dT[0-2]d:[0-5]d:[0-5]d.d{3,}([+-][0-2]d(:?[0-5]d)?|Z)$'
```