### PR TITLE
wip: add nestjs fully working example

### DIFF
--- a/examples/nestjs/consumer/.eslintrc.js
+++ b/examples/nestjs/consumer/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'prettier/@typescript-eslint',
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/examples/nestjs/consumer/.gitignore
+++ b/examples/nestjs/consumer/.gitignore
@@ -1,0 +1,34 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/examples/nestjs/consumer/.prettierrc
+++ b/examples/nestjs/consumer/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/examples/nestjs/consumer/nest-cli.json
+++ b/examples/nestjs/consumer/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/examples/nestjs/consumer/package.json
+++ b/examples/nestjs/consumer/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "pact-nestjs-consumer",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^7.5.1",
+    "@nestjs/core": "^7.5.1",
+    "@nestjs/platform-express": "^7.5.1",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "^6.6.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^7.5.1",
+    "@nestjs/schematics": "^7.1.3",
+    "@nestjs/testing": "^7.5.1",
+    "@pact-foundation/pact": "^9.13.0",
+    "@types/express": "^4.17.8",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.6",
+    "@types/supertest": "^2.0.10",
+    "@typescript-eslint/eslint-plugin": "^4.6.1",
+    "@typescript-eslint/parser": "^4.6.1",
+    "eslint": "^7.12.1",
+    "eslint-config-prettier": "7.0.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "jest": "^26.6.3",
+    "nestjs-pact": "^1.0.3",
+    "prettier": "^2.1.2",
+    "supertest": "^6.0.0",
+    "ts-jest": "^26.4.3",
+    "ts-loader": "^8.0.8",
+    "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "typescript": "^4.0.5"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "testEnvironment": "node"
+  }
+}

--- a/examples/nestjs/consumer/src/animal.interface.ts
+++ b/examples/nestjs/consumer/src/animal.interface.ts
@@ -1,0 +1,19 @@
+export interface Animal {
+  id: number;
+  first_name: string;
+  last_name: string;
+  animal: string;
+  age: number;
+  available_from: Date;
+  gender: 'M' | 'F';
+  location: {
+    description: string;
+    country: string;
+    post_code: number;
+  };
+  eligibility: {
+    available: boolean;
+    previously_married: boolean;
+  };
+  interests: string[];
+}

--- a/examples/nestjs/consumer/src/app.controller.ts
+++ b/examples/nestjs/consumer/src/app.controller.ts
@@ -1,0 +1,20 @@
+import { BadRequestException, Controller, Get, Param } from '@nestjs/common';
+import { AppService } from './app.service';
+import { Animal } from './animal.interface';
+
+@Controller('/')
+export class AppController {
+  public constructor(private readonly appService: AppService) {}
+
+  @Get('/suggestions/:animalId')
+  public async getAllAnimals(
+    @Param('animalId') animalId: string,
+  ): Promise<Animal> {
+    try {
+      const animal = await this.appService.getAnimalById(animalId);
+      return await this.appService.suggestion(animal);
+    } catch (e) {
+      throw new BadRequestException();
+    }
+  }
+}

--- a/examples/nestjs/consumer/src/app.module.ts
+++ b/examples/nestjs/consumer/src/app.module.ts
@@ -1,0 +1,10 @@
+import { HttpModule, Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/examples/nestjs/consumer/src/app.service.ts
+++ b/examples/nestjs/consumer/src/app.service.ts
@@ -1,0 +1,75 @@
+import { HttpService, Injectable } from '@nestjs/common';
+import { Animal } from './animal.interface';
+
+@Injectable()
+export class AppService {
+  private static readonly API_ENDPOINT =
+    process.env.API_HOST || 'http://localhost:3000';
+
+  private static readonly AUTH_HEADER = {
+    Authorization: 'Bearer token',
+  };
+
+  public constructor(private readonly http: HttpService) {}
+
+  public async availableAnimals(): Promise<Animal[]> {
+    const { data } = await this.http
+      .get(`${AppService.API_ENDPOINT}/animals/available`, {
+        headers: { ...AppService.AUTH_HEADER },
+      })
+      .toPromise();
+
+    return data;
+  }
+
+  public async getAnimalById(id: string | number): Promise<Animal> {
+    const { data } = await this.http
+      .get(`${AppService.API_ENDPOINT}/animals/${id}`, {
+        headers: { ...AppService.AUTH_HEADER },
+      })
+      .toPromise();
+
+    return data;
+  }
+
+  public async suggestion(mate: Animal): Promise<any> {
+    const predicates = [
+      (candidate, animal) => candidate.id !== animal.id,
+      (candidate, animal) => candidate.gender !== animal.gender,
+      (candidate, animal) => candidate.animal === animal.animal,
+    ];
+
+    const weights = [
+      (candidate, animal) => Math.abs(candidate.age - animal.age),
+    ];
+
+    return this.availableAnimals().then((availableAnimals: Animal[]) => {
+      const eligible = availableAnimals.filter(
+        a => !predicates.map(p => p(a, mate)).includes(false),
+      );
+
+      return {
+        suggestions: eligible.map(candidateAnimal => {
+          const score = weights.reduce((acc, weight) => {
+            return acc - weight(candidateAnimal, mate);
+          }, 100);
+
+          return {
+            score,
+            animal: candidateAnimal,
+          };
+        }),
+      };
+    });
+  }
+
+  public async createMateForDates(mate: Animal): Promise<Animal> {
+    const { data } = await this.http
+      .post(`${AppService.API_ENDPOINT}/animals`, mate, {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      })
+      .toPromise();
+
+    return data;
+  }
+}

--- a/examples/nestjs/consumer/src/main.ts
+++ b/examples/nestjs/consumer/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(4000);
+}
+
+bootstrap();

--- a/examples/nestjs/consumer/test/app.spec.ts
+++ b/examples/nestjs/consumer/test/app.spec.ts
@@ -1,0 +1,260 @@
+import { Test } from '@nestjs/testing';
+import { PactFactory } from 'nestjs-pact';
+import { AppModule } from '../src/app.module';
+import { PactModule } from './pact/pact.module';
+import { Matchers, Pact } from '@pact-foundation/pact';
+import { AppService } from '../src/app.service';
+import { Animal } from '../src/animal.interface';
+
+jest.setTimeout(99999);
+
+describe('Pact', () => {
+  let pactFactory: PactFactory;
+  let provider: Pact;
+  let animalsService: AppService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, PactModule],
+    }).compile();
+
+    pactFactory = moduleRef.get(PactFactory);
+
+    provider = pactFactory.createContractBetween({
+      consumer: 'Matching Service',
+      provider: 'Animal Profile Service',
+    });
+
+    animalsService = moduleRef.get(AppService);
+
+    /*
+     * Setup a Mock Server before unit tests run.
+     * This server acts as a Test Double for the real Provider API.
+     * We then call addInteraction() for each test to configure the Mock Service
+     * to act like the Provider
+     * It also sets up expectations for what requests are to come, and will fail
+     * if the calls are not seen.
+     */
+    const { port } = await provider.setup();
+    process.env.API_HOST = `http://localhost:${port}`;
+  });
+
+  // Alias flexible matchers for simplicity
+  const { eachLike, like, term, iso8601DateTimeWithMillis } = Matchers;
+
+  // Animal we want to match :)
+  const suitor: Animal = {
+    id: 2,
+    available_from: new Date('2017-12-04T14:47:18.582Z'),
+    first_name: 'Nanny',
+    animal: 'goat',
+    last_name: 'Doe',
+    age: 27,
+    gender: 'F',
+    location: {
+      description: 'Werribee Zoo',
+      country: 'Australia',
+      post_code: 3000,
+    },
+    eligibility: {
+      available: true,
+      previously_married: true,
+    },
+    interests: ['walks in the garden/meadow', 'parkour'],
+  };
+
+  const MIN_ANIMALS = 2;
+
+  /*
+   * Define animal payload, with flexible matchers
+   * This makes the test much more resilient to changes in actual data.
+   * Here we specify the 'shape' of the object that we care about.
+   * It is also import here to not put in expectations for parts of the
+   * API we don't care about
+   */
+  const animalBodyExpectation = {
+    id: like(1),
+    available_from: iso8601DateTimeWithMillis(),
+    first_name: like('Billy'),
+    last_name: like('Goat'),
+    animal: like('goat'),
+    age: like(21),
+    gender: term({
+      matcher: 'F|M',
+      generate: 'M',
+    }),
+    location: {
+      description: like('Melbourne Zoo'),
+      country: like('Australia'),
+      post_code: like(3000),
+    },
+    eligibility: {
+      available: like(true),
+      previously_married: like(false),
+    },
+    interests: eachLike('walks in the garden/meadow'),
+  };
+
+  // Define animal list payload, reusing existing object matcher
+  const animalListExpectation = eachLike(animalBodyExpectation, {
+    min: MIN_ANIMALS,
+  });
+
+  // After each individual test (one or more interactions)
+  // we validate that the correct request came through.
+  // This ensures what we _expect_ from the provider, is actually
+  // what we've asked for (and is what gets captured in the contract)
+  afterEach(() => provider.verify());
+
+  // Configure and import consumer API
+  // Note that we update the API endpoint to point at the Mock Service
+
+  // Verify service client works as expected.
+  //
+  // Note that we don't call the consumer API endpoints directly, but
+  // use unit-style tests that test the collaborating function behaviour -
+  // we want to test the function that is calling the external service.
+  describe('when a call to list all animals from the Animal Service is made', () => {
+    describe('and the user is not authenticated', () => {
+      beforeAll(() =>
+        provider.addInteraction({
+          state: 'is not authenticated',
+          uponReceiving: 'a request for all animals',
+          withRequest: {
+            method: 'GET',
+            path: '/animals/available',
+          },
+          willRespondWith: {
+            status: 401,
+          },
+        }),
+      );
+
+      it('returns a 401 unauthorized', () => {
+        return expect(animalsService.suggestion(suitor)).rejects.toThrowError();
+      });
+    });
+
+    describe('and the user is authenticated', () => {
+      describe('and there are animals in the database', () => {
+        beforeAll(() =>
+          provider.addInteraction({
+            state: 'Has some animals',
+            uponReceiving: 'a request for all animals',
+            withRequest: {
+              method: 'GET',
+              path: '/animals/available',
+              headers: { Authorization: 'Bearer token' },
+            },
+            willRespondWith: {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+              },
+              body: animalListExpectation,
+            },
+          }),
+        );
+
+        it('returns a list of animals', async () => {
+          const suggestedMates = await animalsService.suggestion(suitor);
+
+          expect(suggestedMates).toHaveProperty('suggestions');
+
+          const { suggestions } = suggestedMates;
+
+          expect(suggestions).toHaveLength(MIN_ANIMALS);
+          expect(suggestions[0].score).toBe(94);
+        });
+      });
+    });
+  });
+
+  describe('when a call to the Animal Service is made to retreive a single animal by ID', () => {
+    describe('and there is an animal in the DB with ID 1', () => {
+      beforeAll(() =>
+        provider.addInteraction({
+          state: 'Has an animal with ID 1',
+          uponReceiving: 'a request for an animal with ID 1',
+          withRequest: {
+            method: 'GET',
+            path: term({ generate: '/animals/1', matcher: '/animals/[0-9]+' }),
+            headers: { Authorization: 'Bearer token' },
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8',
+            },
+            body: animalBodyExpectation,
+          },
+        }),
+      );
+
+      it('returns the animal', async () => {
+        const suggestedMates = await animalsService.getAnimalById(11);
+
+        expect(suggestedMates).toHaveProperty('id', 1);
+      });
+    });
+
+    describe('and there no animals in the database', () => {
+      beforeAll(() =>
+        provider.addInteraction({
+          state: 'Has no animals',
+          uponReceiving: 'a request for an animal with ID 100',
+          withRequest: {
+            method: 'GET',
+            path: '/animals/100',
+            headers: { Authorization: 'Bearer token' },
+          },
+          willRespondWith: {
+            status: 404,
+          },
+        }),
+      );
+
+      it('returns a 404', async () => {
+        // uncomment below to test a failed verify
+        // const suggestedMates = await animalsService.getAnimalById(123)
+        const suggestedMates = animalsService.getAnimalById(100);
+
+        await expect(suggestedMates).rejects.toThrowError();
+      });
+    });
+  });
+
+  describe('when a call to the Animal Service is made to create a new mate', () => {
+    beforeAll(() =>
+      provider.addInteraction({
+        state: undefined,
+        uponReceiving: 'a request to create a new mate',
+        withRequest: {
+          method: 'POST',
+          path: '/animals',
+          body: like(suitor),
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+          body: like(suitor),
+        },
+      }),
+    );
+
+    it('creates a new mate', async () => {
+      const result = animalsService.createMateForDates(suitor);
+
+      await expect(result).resolves.toBe(Object);
+    });
+  });
+
+  afterEach(() => provider.verify());
+
+  afterAll(() => provider.finalize());
+});

--- a/examples/nestjs/consumer/test/pact/pact-consumer-config-options.service.ts
+++ b/examples/nestjs/consumer/test/pact/pact-consumer-config-options.service.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import { Injectable } from '@nestjs/common';
+import {
+  PactConsumerOptionsFactory,
+  PactConsumerOverallOptions,
+} from 'nestjs-pact';
+import { exec } from 'child_process';
+
+@Injectable()
+export class PactConsumerConfigOptionsService
+  implements PactConsumerOptionsFactory {
+  createPactConsumerOptions(): PactConsumerOverallOptions {
+    // Usually, you would just use the CI env vars, but to allow these examples to run from
+    // local development machines, we'll fall back to the git command when the env vars aren't set.
+    const gitSha = process.env.TRAVIS_COMMIT || exec('git rev-parse HEAD');
+    const branch =
+      process.env.TRAVIS_BRANCH || exec('git rev-parse --abbrev-ref HEAD');
+
+    return {
+      consumer: {
+        // port: 1234, // You can set the port explicitly here or dynamically (see setup() below)
+        log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+        dir: path.resolve(process.cwd(), 'pacts'),
+        logLevel: 'warn',
+        spec: 2,
+      },
+      publication: {
+        pactFilesOrDirs: [path.resolve(process.cwd(), 'pacts')],
+        pactBroker: 'https://test.pact.dius.com.au',
+        pactBrokerUsername: 'dXfltyFMgNOFZAxr8io9wJ37iUpY42M',
+        pactBrokerPassword: 'O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1',
+        consumerVersion: (gitSha as string) || '1.0.0',
+        tags: [(branch as string) || 'master'],
+      },
+    };
+  }
+}

--- a/examples/nestjs/consumer/test/pact/pact.module.ts
+++ b/examples/nestjs/consumer/test/pact/pact.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PactConsumerModule } from 'nestjs-pact';
+import { PactConsumerConfigOptionsService } from './pact-consumer-config-options.service';
+import { AppModule } from '../../src/app.module';
+
+@Module({
+  imports: [
+    PactConsumerModule.registerAsync({
+      imports: [AppModule],
+      useClass: PactConsumerConfigOptionsService,
+    }),
+  ],
+})
+export class PactModule {}

--- a/examples/nestjs/consumer/tsconfig.build.json
+++ b/examples/nestjs/consumer/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/examples/nestjs/consumer/tsconfig.json
+++ b/examples/nestjs/consumer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "types": [
+      "node",
+      "jest"
+    ]
+  }
+}

--- a/examples/nestjs/provider/.eslintrc.js
+++ b/examples/nestjs/provider/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'prettier/@typescript-eslint',
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/examples/nestjs/provider/.gitignore
+++ b/examples/nestjs/provider/.gitignore
@@ -1,0 +1,34 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/examples/nestjs/provider/.prettierrc
+++ b/examples/nestjs/provider/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/examples/nestjs/provider/data/animal-data.json
+++ b/examples/nestjs/provider/data/animal-data.json
@@ -1,0 +1,66 @@
+[
+  {
+    "first_name": "Billy",
+    "last_name": "Goat",
+    "animal": "goat",
+    "age": 21,
+    "available_from": "2017-12-04T14:47:18.582Z",
+    "gender": "M",
+    "location": {
+      "description": "Melbourne Zoo",
+      "country": "Australia",
+      "post_code": 3000
+    },
+    "eligibility": {
+      "available": true,
+      "previously_married": false
+    },
+    "interests": [
+      "walks in the garden/meadow",
+      "munching on a paddock bomb",
+      "parkour"
+    ]
+  },
+  {
+    "first_name": "Nanny",
+    "animal": "goat",
+    "last_name": "Doe",
+    "age": 27,
+    "available_from": "2017-12-04T14:47:18.582Z",
+    "gender": "F",
+    "location": {
+      "description": "Werribee Zoo",
+      "country": "Australia",
+      "post_code": 3000
+    },
+    "eligibility": {
+      "available": true,
+      "previously_married": true
+    },
+    "interests": [
+      "walks in the garden/meadow",
+      "parkour"
+    ]
+  },
+  {
+    "first_name": "Simba",
+    "last_name": "Cantwaittobeking",
+    "animal": "lion",
+    "age": 4,
+    "available_from": "2017-12-04T14:47:18.582Z",
+    "gender": "M",
+    "location": {
+      "description": "Werribee Zoo",
+      "country": "Australia",
+      "post_code": 3000
+    },
+    "eligibility": {
+      "available": true,
+      "previously_married": true
+    },
+    "interests": [
+      "walks in the garden/meadow",
+      "parkour"
+    ]
+  }
+]

--- a/examples/nestjs/provider/nest-cli.json
+++ b/examples/nestjs/provider/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/examples/nestjs/provider/package.json
+++ b/examples/nestjs/provider/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "pact-nestjs-provider",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^7.5.1",
+    "@nestjs/core": "^7.5.1",
+    "@nestjs/platform-express": "^7.5.1",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "^6.6.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^7.5.1",
+    "@nestjs/schematics": "^7.1.3",
+    "@nestjs/testing": "^7.5.1",
+    "@pact-foundation/pact": "^9.13.0",
+    "@types/express": "^4.17.8",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.6",
+    "@types/supertest": "^2.0.10",
+    "@typescript-eslint/eslint-plugin": "^4.6.1",
+    "@typescript-eslint/parser": "^4.6.1",
+    "eslint": "^7.12.1",
+    "eslint-config-prettier": "7.0.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "jest": "^26.6.3",
+    "nestjs-pact": "^1.0.3",
+    "prettier": "^2.1.2",
+    "supertest": "^6.0.0",
+    "ts-jest": "^26.4.3",
+    "ts-loader": "^8.0.8",
+    "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "typescript": "^4.0.5"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "testEnvironment": "node"
+  }
+}

--- a/examples/nestjs/provider/src/animal.interface.ts
+++ b/examples/nestjs/provider/src/animal.interface.ts
@@ -1,0 +1,19 @@
+export interface Animal {
+  id: number;
+  first_name: string;
+  last_name: string;
+  animal: string;
+  age: number;
+  available_from: Date;
+  gender: 'M' | 'F';
+  location: {
+    description: string;
+    country: string;
+    post_code: number;
+  };
+  eligibility: {
+    available: boolean;
+    previously_married: boolean;
+  };
+  interests: string[];
+}

--- a/examples/nestjs/provider/src/app.controller.ts
+++ b/examples/nestjs/provider/src/app.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { AppService } from './app.service';
+import { Animal } from './animal.interface';
+import { AppRepository } from './app.repository';
+
+@Controller('/animals')
+export class AppController {
+  public constructor(
+    private readonly appService: AppService,
+    private readonly repository: AppRepository,
+  ) {}
+
+  @Get('/')
+  public getAllAnimals(): Animal[] {
+    return this.repository.fetchAll();
+  }
+
+  @Get('/available')
+  public availableAnimals(): Animal[] {
+    return this.appService.availableAnimals();
+  }
+
+  @Get('/:id')
+  @HttpCode(HttpStatus.NOT_FOUND)
+  public getAnimalById(@Param('id') id: number): Animal {
+    const result = this.repository.getById(id);
+
+    if (!result) {
+      throw new NotFoundException('Animal not found');
+    }
+
+    return result;
+  }
+
+  @Post('/')
+  public createAnimal(@Body() animal: Animal): Animal {
+    return this.repository.insert(animal);
+  }
+}

--- a/examples/nestjs/provider/src/app.module.ts
+++ b/examples/nestjs/provider/src/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { AppRepository } from './app.repository';
+
+@Module({
+  controllers: [AppController],
+  providers: [AppService, AppRepository],
+  exports: [AppRepository],
+})
+export class AppModule {}

--- a/examples/nestjs/provider/src/app.repository.ts
+++ b/examples/nestjs/provider/src/app.repository.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Injectable } from '@nestjs/common';
+import { Animal } from './animal.interface';
+
+@Injectable()
+export class AppRepository {
+  private entities: Animal[];
+
+  public constructor() {
+    this.entities = [];
+    this.importData();
+  }
+
+  public importData(): void {
+    const data = (fs.readFileSync(
+      path.resolve('./data/animal-data.json'),
+      'utf-8',
+    ) as unknown) as string;
+
+    JSON.parse(data).reduce((animal, value) => {
+      value.id = animal + 1;
+      this.insert(value);
+      return animal + 1;
+    }, 0);
+  }
+
+  public fetchAll(): Animal[] {
+    return this.entities;
+  }
+
+  public getById(id: number): Animal {
+    return this.entities.find((entity) => id == entity.id);
+  }
+
+  public insert(entity: Animal): Animal {
+    const newEntity = {
+      id: this.entities.length + 1,
+      ...entity,
+    };
+
+    this.entities.push(newEntity);
+
+    return newEntity;
+  }
+
+  public clear() {
+    this.entities = [];
+  }
+}

--- a/examples/nestjs/provider/src/app.service.ts
+++ b/examples/nestjs/provider/src/app.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { AppRepository } from './app.repository';
+import { Animal } from './animal.interface';
+
+@Injectable()
+export class AppService {
+  public constructor(private readonly repository: AppRepository) {}
+
+  public availableAnimals(): Animal[] {
+    return this.repository.fetchAll().filter((animal) => {
+      return animal.eligibility.available;
+    });
+  }
+}

--- a/examples/nestjs/provider/src/main.ts
+++ b/examples/nestjs/provider/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/examples/nestjs/provider/test/app.spec.ts
+++ b/examples/nestjs/provider/test/app.spec.ts
@@ -1,0 +1,37 @@
+import { Test } from '@nestjs/testing';
+import { PactVerifierService } from 'nestjs-pact';
+import { INestApplication, Logger, LoggerService } from '@nestjs/common';
+import { AppModule } from '../src/app.module';
+import { AppRepository } from '../src/app.repository';
+import { PactModule } from './pact/pact.module';
+
+describe('Pact Verification', () => {
+  let verifierService: PactVerifierService;
+  let logger: LoggerService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, PactModule],
+      providers: [AppRepository, Logger],
+    }).compile();
+
+    verifierService = moduleRef.get(PactVerifierService);
+    logger = moduleRef.get(Logger);
+
+    app = moduleRef.createNestApplication();
+
+    await app.init();
+  });
+
+  it('validates the expectations of Matching Service', async () => {
+    const output = await verifierService.verify(app);
+
+    logger.log('Pact Verification Complete!');
+    logger.log(output);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/examples/nestjs/provider/test/pact/pact-producer-config-options.service.ts
+++ b/examples/nestjs/provider/test/pact/pact-producer-config-options.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PactProducerOptionsFactory, PactProducerOptions } from 'nestjs-pact';
+import { AppRepository } from '../../src/app.repository';
+
+@Injectable()
+export class PactProducerConfigOptionsService
+  implements PactProducerOptionsFactory {
+  public constructor(
+    private readonly animalRepository: AppRepository,
+    private readonly config: ConfigService,
+  ) {}
+
+  public createPactProducerOptions(): PactProducerOptions {
+    let token;
+
+    return {
+      provider: 'Animal Profile Service',
+      logLevel: this.config.get('pact.logLevel'),
+
+      requestFilter: (req, res, next) => {
+        console.log(
+          'Middleware invoked before provider API - injecting Authorization token',
+        );
+        req.headers['MY_SPECIAL_HEADER'] = 'my special value';
+
+        // e.g. ADD Bearer token
+        req.headers['authorization'] = `Bearer ${token}`;
+        next();
+      },
+
+      stateHandlers: {
+        'Has no animals': async () => {
+          this.animalRepository.clear();
+          token = '1234';
+          return 'Animals removed to the db';
+        },
+        'Has some animals': async () => {
+          token = '1234';
+          this.animalRepository.importData();
+          return 'Animals added to the db';
+        },
+        'Has an animal with ID 1': async () => {
+          token = '1234';
+          this.animalRepository.importData();
+
+          return 'Animals added to the db';
+        },
+        'is not authenticated': async () => {
+          token = '';
+          return 'Invalid bearer token generated';
+        },
+      },
+
+      // Fetch pacts from broker
+      pactBrokerUrl: 'https://test.pact.dius.com.au/',
+      consumerVersionTags: ['prod'],
+      providerVersionTags: ['prod'],
+      enablePending: true,
+      pactBrokerUsername: 'dXfltyFMgNOFZAxr8io9wJ37iUpY42M',
+      pactBrokerPassword: 'O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1',
+      publishVerificationResult: true,
+      providerVersion: '1.0.0',
+    };
+  }
+}

--- a/examples/nestjs/provider/test/pact/pact.module.ts
+++ b/examples/nestjs/provider/test/pact/pact.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { PactProducerModule } from 'nestjs-pact';
+import { PactProducerConfigOptionsService } from './pact-producer-config-options.service';
+import { AppRepository } from '../../src/app.repository';
+import { AppModule } from '../../src/app.module';
+
+@Module({
+  imports: [
+    PactProducerModule.registerAsync({
+      imports: [AppModule],
+      useClass: PactProducerConfigOptionsService,
+      inject: [AppRepository],
+    }),
+  ],
+})
+export class PactModule {}

--- a/examples/nestjs/provider/tsconfig.build.json
+++ b/examples/nestjs/provider/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/examples/nestjs/provider/tsconfig.json
+++ b/examples/nestjs/provider/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "types": [
+      "node",
+      "jest"
+    ]
+  }
+}


### PR DESCRIPTION
Add fully working, end-to-end NestJS example with consumer and provider, stick to the original example from `e2e` folder

See issue "Proposal: Add NestJS Full Working Example (#[543](https://github.com/pact-foundation/pact-js/issues/543))"
