### PR TITLE
chore(docs): Correct links to karma examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,8 +883,8 @@ The workshop takes you through all of the key concepts using a React consumer an
 - [Pact with TypeScript + Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/typescript)
 - [Pact with Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/mocha)
 - [Pact with GraphQL](https://github.com/pact-foundation/pact-js/tree/master/examples/graphql)
-- [Pact with Karma + Jasmine](https://github.com/pact-foundation/pact-js/tree/master/karma/jasmine)
-- [Pact with Karma + Mocha](https://github.com/pact-foundation/pact-js/tree/master/karma/mocha)
+- [Pact with Karma + Jasmine](https://github.com/pact-foundation/pact-js/tree/master/examples/karma/jasmine)
+- [Pact with Karma + Mocha](https://github.com/pact-foundation/pact-js/tree/master/examples/karma/mocha)
 - [Pact with React + Jest](https://github.com/pact-foundation/pact-workshop-js)
 
 ### Asynchronous APIs


### PR DESCRIPTION
the examples live inside the `/examples` folder, so correct the links