### PR TITLE
fix: don't JSON.stringify body if its already a string

### DIFF
--- a/examples/v3/e2e/consumer.js
+++ b/examples/v3/e2e/consumer.js
@@ -60,11 +60,11 @@ const suggestion = (mate, api) => {
 }
 
 // Creates a mate for suggestions
-const createMateForDates = (mate, api = getApiEndpoint) => {
+const createMateForDates = (mate, api = getApiEndpoint, contentType = 'application/json' ) => {
   return request
     .post(`${api()}/animals`)
     .send(mate)
-    .set("Content-Type", "application/json; charset=utf-8")
+    .set("Content-Type", contentType + "; charset=utf-8")
 }
 
 // Suggestions API

--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -264,6 +264,45 @@ describe("Pact V3", () => {
     })
   })
 
+  describe("when a call to the Animal Service is made to create a new mate using form-data body", () => {
+    const provider = new PactV3({
+      consumer: "Matching Service V3",
+      provider: "Animal Profile Service V3",
+      dir: path.resolve(process.cwd(), "pacts"),
+    })
+
+    before(() =>
+      provider
+        .given("is authenticated")
+        .uponReceiving("a request to create a new mate")
+        .withRequest({
+          method: "POST",
+          path: "/animals",
+          body: "first_name=Nanny&last_name=Doe",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+        .willRespondWith({
+          status: 200,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+          },
+          body: like(suitor),
+        })
+    )
+
+    it("creates a new mate with application/x-www-form-urlencoded", () => {
+      return provider.executeTest(mockserver => {
+        return expect(createMateForDates(
+          "first_name=Nanny&last_name=Doe",
+          () => mockserver.url,
+          "application/x-www-form-urlencoded")).to
+          .eventually.be.fulfilled
+      })
+    })
+  })
+
   describe("when a call to the Animal Service is made to get animals in XML format", () => {
     const provider = new PactV3({
       consumer: "Matching Service V3",

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -136,7 +136,11 @@ export class PactV3 {
   }
 
   public withRequest(req: V3Request): PactV3 {
-    this.pact.addRequest(req, req.body && JSON.stringify(req.body))
+    let body = req.body
+    if (typeof body !== 'string') {
+      body = body && JSON.stringify(body)
+    }
+    this.pact.addRequest(req, body)
     return this
   }
 


### PR DESCRIPTION
if the body is already a string don't try to stringify it

fixes #577 

alternatively we could get rid of `JSON.stringify` all together, the limited e2e tests also pass then