### PR TITLE
fix: increase provider test timeout

### DIFF
--- a/examples/messages/package.json
+++ b/examples/messages/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf pacts",
     "test": "npm run test:consumer && npm run test:publish && npm run test:provider",
     "test:consumer": "nyc --check-coverage --reporter=html --reporter=text-summary mocha consumer/*.spec.ts",
-    "test:provider": "nyc --check-coverage --reporter=html --reporter=text-summary mocha -t 10000 provider/*.spec.ts",
+    "test:provider": "nyc --check-coverage --reporter=html --reporter=text-summary mocha -t 20000 provider/*.spec.ts",
     "test:publish": "node publish.js"
   },
   "author": "",


### PR DESCRIPTION
those tests failed for me now several times with the 10sec timeout  see https://github.com/pact-foundation/pact-js/pull/578#issuecomment-762100126 so 20sec should make them more robust