### PR TITLE
fix: e2e test examples for V3

### DIFF
--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -160,7 +160,9 @@ describe("Pact V3", () => {
   })
 
   describe("when a call to the Animal Service is made to retrieve a single animal by ID", () => {
-    describe("and there is an animal in the DB with ID 1", () => {
+    describe("and there is an animal in the DB with ID 100", () => {
+      let responseBody = animalBodyExpectation
+      responseBody.id = 100
       const provider = new PactV3({
         consumer: "Matching Service V3",
         provider: "Animal Profile Service V3",
@@ -175,7 +177,7 @@ describe("Pact V3", () => {
           })
           .uponReceiving("a request for an animal with an ID")
           .withRequest({
-            path: regex("/animals/[0-9]+", "/animals/1"),
+            path: regex("/animals/[0-9]+", "/animals/100"),
             headers: { Authorization: "Bearer token" },
           })
           .willRespondWith({
@@ -183,15 +185,15 @@ describe("Pact V3", () => {
             headers: {
               "Content-Type": "application/json; charset=utf-8",
             },
-            body: animalBodyExpectation,
+            body: responseBody,
           })
       )
 
       it("returns the animal", () => {
         return provider.executeTest(mockserver => {
-          const animal = getAnimalById(1, () => mockserver.url)
+          const animal = getAnimalById(100, () => mockserver.url)
 
-          return expect(animal).to.eventually.have.deep.property("id", 1)
+          return expect(animal).to.eventually.have.deep.property("id", 100)
         })
       })
     })

--- a/examples/v3/e2e/test/provider.spec.js
+++ b/examples/v3/e2e/test/provider.spec.js
@@ -85,7 +85,7 @@ describe("Pact Verification", () => {
       // pactUrls: [
       //   path.resolve(
       //     process.cwd(),
-      //     "./pacts/matching_service-animal_profile_service.json"
+      //     "./pacts/Matching Service V3-Animal Profile Service V3.json"
       //   ),
       // ],
 


### PR DESCRIPTION
1. the local pact file has an other path than given in the comment
2. fix the expected animal-id
    the `.given()` function would set up animal with the id `100` but the test would query and expect id `1` back
    it all worked when running all tests together because id `1` was setup earlier, but the test would fail when running only this test as consumer (`./node_modules/.bin/mocha test/consumer.spec.js --grep 'returns the animal'`) and then verifying the pact by the provider 