### PR TITLE
fix: don't strigify response that is already a string

### DIFF
--- a/examples/v3/e2e/consumer.js
+++ b/examples/v3/e2e/consumer.js
@@ -17,14 +17,20 @@ const availableAnimals = (api = getApiEndpoint) => {
 }
 
 // Find animals by their ID from the Animal Service
-const getAnimalById = (id, api = getApiEndpoint) => {
-  return request
+const getAnimalById = (id, api = getApiEndpoint, format = 'application/json') => {
+  let r = request
     .get(`${api()}/animals/${id}`)
     .set(authHeader)
-    .then(
-      res => res.body,
-      () => null
-    )
+    .set({Accept: format})
+
+  if (format === 'text/plain') {
+    return r.then(res => res.text)
+  }
+
+  return r.then(
+    res => res.body,
+    () => null
+  )
 }
 
 // Suggestions function:

--- a/examples/v3/e2e/provider.js
+++ b/examples/v3/e2e/provider.js
@@ -73,7 +73,12 @@ server.get("/animals/available/xml", (req, res) => {
 server.get("/animals/:id", (req, res) => {
   const response = animalRepository.getById(req.params.id)
   if (response) {
-    res.end(JSON.stringify(response))
+    if (req.header('accept') === 'text/plain') {
+      res.contentType('text/plain; charset=utf-8')
+      res.end(`id=${response.id};first_name=${response.first_name};last_name=${response.last_name};animal=${response.animal}`)
+    } else {
+      res.end(JSON.stringify(response))
+    }
   } else {
     res.writeHead(404)
     res.end()

--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -230,6 +230,47 @@ describe("Pact V3", () => {
     })
   })
 
+  describe("when a call to the Animal Service is made to retrieve a single animal in text by ID", () => {
+    describe("and there is an animal in the DB with ID 100", () => {
+
+      const provider = new PactV3({
+        consumer: "Matching Service V3",
+        provider: "Animal Profile Service V3",
+        dir: path.resolve(process.cwd(), "pacts")
+      })
+
+      before(() =>
+        provider
+          .given("is authenticated")
+          .given("Has an animal with ID", {
+            id: 100,
+          })
+          .uponReceiving("a request for an animal as text with an ID")
+          .withRequest({
+            path: regex("/animals/[0-9]+", "/animals/100"),
+            headers: {
+              Authorization: "Bearer token",
+              Accept: "text/plain"
+            },
+          })
+          .willRespondWith({
+            status: 200,
+            headers: {
+              "Content-Type": "text/plain; charset=utf-8",
+            },
+            body: 'id=100;first_name=Nanny;last_name=Doe;animal=goat',
+          })
+      )
+
+      it("returns the animal", async () => {
+        return provider.executeTest(async mockserver =>  {
+          const animal = await getAnimalById(100, () => mockserver.url, 'text/plain')
+          return expect(animal).to.equal('id=100;first_name=Nanny;last_name=Doe;animal=goat')
+        })
+      })
+    })
+  })
+
   describe("when a call to the Animal Service is made to create a new mate", () => {
     const provider = new PactV3({
       consumer: "Matching Service V3",

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -164,7 +164,11 @@ export class PactV3 {
   }
 
   public willRespondWith(res: V3Response): PactV3 {
-    this.pact.addResponse(res, res.body && JSON.stringify(res.body))
+    let body = res.body
+    if (typeof body !== 'string') {
+      body = body && JSON.stringify(body)
+    }
+    this.pact.addResponse(res, body)
     this.states = []
     return this
   }


### PR DESCRIPTION
### PR Template
analog to https://github.com/pact-foundation/pact-js/pull/578 the response body does not need any stringify if its already a string otherwise an extra pair of quotes is added
```
      AssertionError: expected '"id=100;first_name=Billy;last_name=Goat;animal=goat"' to equal 'id=100;first_name=Billy;last_name=Goat;animal=goat'
      + expected - actual

      -"id=100;first_name=Billy;last_name=Goat;animal=goat"
      +id=100;first_name=Billy;last_name=Goat;animal=goat
```
