### PR TITLE
fix: MatchersV3 don't work for body content

### DIFF
--- a/examples/v3/provider-state-injected/consumer/transaction-service.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.js
@@ -33,4 +33,16 @@ module.exports = {
         }
       })
   },
+
+  getXml: (id) => {
+    return axios.get(accountServiceUrl + "/data/xml/" + id).then((data) => {
+      return data
+    })
+  },
+
+  getText: (id) => {
+    return axios.get(accountServiceUrl + "/data/" + id).then((data) => {
+      return data
+    })
+  },
 }

--- a/examples/v3/provider-state-injected/consumer/transaction-service.test.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.test.js
@@ -1,12 +1,12 @@
 const path = require("path")
 const transactionService = require("./transaction-service")
-const { PactV3, MatchersV3 } = require("@pact-foundation/pact/v3")
+const { PactV3, MatchersV3, XmlBuilder } = require("@pact-foundation/pact/v3")
 const { expect } = require("chai")
 const { string, integer, url2, regex, datetime, fromProviderState } = MatchersV3
 
 describe("Transaction service - create a new transaction for an account", () => {
   let provider
-  beforeAll(() => {
+  beforeEach(() => {
     provider = new PactV3({
       consumer: "TransactionService",
       provider: "AccountService",
@@ -62,6 +62,32 @@ describe("Transaction service - create a new transaction for an account", () => 
           expect(result.account.accountNumber).to.equal(100)
           expect(result.transaction.amount).to.equal(100000)
         })
+    })
+  })
+
+  // MatchersV3.fromProviderState on body
+  it("test text data", () => {
+    provider
+      .given("set id", { id: "42" })
+      .uponReceiving("a request to get the plain data")
+      .withRequest({
+        method: "GET",
+        path: MatchersV3.fromProviderState("/data/${id}", "/data/42"),
+      })
+      .willRespondWith({
+        status: 200,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+        body: MatchersV3.fromProviderState(
+          "data: testData, id: ${id}",
+          "data: testData, id: 42"
+        ),
+      })
+
+    return provider.executeTest(async (mockserver) => {
+      transactionService.setAccountServiceUrl(mockserver.url)
+      return transactionService.getText(42).then((result) => {
+        expect(result.data).to.equal("data: testData, id: 42")
+      })
     })
   })
 })

--- a/examples/v3/provider-state-injected/provider/account-service.js
+++ b/examples/v3/provider-state-injected/provider/account-service.js
@@ -45,6 +45,24 @@ server.get("/accounts/search/findOneByAccountNumberId", (req, res) => {
     })
 })
 
+server.get("/data/xml/:id", (req, res) => {
+  res.header("Content-Type", "application/xml; charset=utf-8")
+  res.send(`<?xml version="1.0" encoding="UTF-8"?>
+  <root xmlns:h="http://www.w3.org/TR/html4/">
+      <data>
+          <h:data>testData</h:data>
+          <id>${req.params.id}</id>
+      </data>
+  </root>`)
+})
+
+server.get("/data/:id", (req, res) => {
+  res.header("Content-Type", "text/plain; charset=utf-8")
+  res.send("data: testData, id: " + req.params.id)
+})
+
+//server.listen(8081)
+
 module.exports = {
   accountService: server,
 }

--- a/examples/v3/provider-state-injected/provider/account-service.test.js
+++ b/examples/v3/provider-state-injected/provider/account-service.test.js
@@ -34,6 +34,16 @@ describe("Account Service", () => {
             return null
           }
         },
+        "set id": (setup, params) => {
+          if (setup) {
+            return { id: params.id }
+          }
+        },
+        "set path": (setup, params) => {
+          if (setup) {
+            return { id: params.id, path: params.path }
+          }
+        },
       },
 
       pactUrls: [

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -196,6 +196,15 @@ export class PactV3 {
 
   public willRespondWith(res: V3Response): PactV3 {
     let body = res.body
+    if (body !== undefined && body !== null) {
+      if (
+        (body as MatchersV3.Matcher<never>)["pact:matcher:type"] !== undefined
+      ) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        body = body?.value
+      }
+    }
     if (typeof body !== "string") {
       body = body && JSON.stringify(body)
     }


### PR DESCRIPTION
using a matcher in the body does return the whole object but we only want the "example" of it, that is stored in the "value" item.
So when a matcher result is returned then extract the "value" out of it and return that.

Fixes #633

What will happen if your body REALLY contains a body that looks like a Matcher 😱
