### PR TITLE
Fix/generators non json bodies

### DIFF
--- a/examples/v3/provider-state-injected/consumer/transaction-service.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.js
@@ -33,4 +33,10 @@ module.exports = {
         }
       })
   },
+
+  getText: (id) => {
+    return axios.get(accountServiceUrl + "/data/" + id).then((data) => {
+      return data
+    })
+  },
 }

--- a/examples/v3/provider-state-injected/consumer/transaction-service.test.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.test.js
@@ -6,7 +6,7 @@ const { string, integer, url2, regex, datetime, fromProviderState } = MatchersV3
 
 describe("Transaction service - create a new transaction for an account", () => {
   let provider
-  beforeAll(() => {
+  beforeEach(() => {
     provider = new PactV3({
       consumer: "TransactionService",
       provider: "AccountService",
@@ -62,6 +62,32 @@ describe("Transaction service - create a new transaction for an account", () => 
           expect(result.account.accountNumber).to.equal(100)
           expect(result.transaction.amount).to.equal(100000)
         })
+    })
+  })
+
+  // MatchersV3.fromProviderState on body
+  it("test text data", () => {
+    provider
+      .given("set id", { id: "42" })
+      .uponReceiving("a request to get the plain data")
+      .withRequest({
+        method: "GET",
+        path: MatchersV3.fromProviderState("/data/${id}", "/data/42"),
+      })
+      .willRespondWith({
+        status: 200,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+        body: MatchersV3.fromProviderState(
+          "data: testData, id: ${id}",
+          "data: testData, id: 42"
+        ),
+      })
+
+    return provider.executeTest(async (mockserver) => {
+      transactionService.setAccountServiceUrl(mockserver.url)
+      return transactionService.getText(42).then((result) => {
+        expect(result.data).to.equal("data: testData, id: 42")
+      })
     })
   })
 })

--- a/examples/v3/provider-state-injected/provider/account-service.js
+++ b/examples/v3/provider-state-injected/provider/account-service.js
@@ -45,6 +45,22 @@ server.get("/accounts/search/findOneByAccountNumberId", (req, res) => {
     })
 })
 
+server.get("/data/xml/:id", (req, res) => {
+  res.header("Content-Type", "application/xml; charset=utf-8")
+  res.send(`<?xml version="1.0" encoding="UTF-8"?>
+  <root xmlns:h="http://www.w3.org/TR/html4/">
+      <data>
+          <h:data>testData</h:data>
+          <id>${req.params.id}</id>
+      </data>
+  </root>`)
+})
+
+server.get("/data/:id", (req, res) => {
+  res.header("Content-Type", "text/plain; charset=utf-8")
+  res.send("data: testData, id: " + req.params.id)
+})
+
 module.exports = {
   accountService: server,
 }

--- a/examples/v3/provider-state-injected/provider/account-service.test.js
+++ b/examples/v3/provider-state-injected/provider/account-service.test.js
@@ -34,6 +34,16 @@ describe("Account Service", () => {
             return null
           }
         },
+        "set id": (setup, params) => {
+          if (setup) {
+            return { id: params.id }
+          }
+        },
+        "set path": (setup, params) => {
+          if (setup) {
+            return { id: params.id, path: params.path }
+          }
+        },
       },
 
       pactUrls: [

--- a/native/index.node.d.ts
+++ b/native/index.node.d.ts
@@ -4,8 +4,9 @@ import {
   V3MockServer,
   V3ProviderState,
   V3Request,
-  V3Response,
+  V3Response
 } from "v3/pact"
+import { AnyTemplate } from "v3/matchers"
 
 export class Pact {
   constructor(
@@ -16,7 +17,7 @@ export class Pact {
   )
   addRequest(
     req: V3Request,
-    body: string | number | boolean | null | undefined
+    body: AnyTemplate | undefined
   ): void
   addInteraction(desc: string, states: V3ProviderState[]): void
   addRequestBinaryFile(req: V3Request, contentType: string, file: string): void
@@ -28,7 +29,7 @@ export class Pact {
   ): void
   addResponse(
     res: V3Response,
-    body: string | number | boolean | null | undefined
+    body: AnyTemplate | undefined
   ): void
 
   addResponseBinaryFile(

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -167,9 +167,6 @@ export class PactV3 {
 
   public withRequest(req: V3Request): PactV3 {
     let { body } = req
-    if (typeof body !== "string") {
-      body = body && JSON.stringify(body)
-    }
     this.pact.addRequest(req, body)
     return this
   }
@@ -195,9 +192,6 @@ export class PactV3 {
 
   public willRespondWith(res: V3Response): PactV3 {
     let { body } = res
-    if (typeof body !== "string") {
-      body = body && JSON.stringify(body)
-    }
     this.pact.addResponse(res, body)
     this.states = []
     return this

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -166,8 +166,7 @@ export class PactV3 {
   }
 
   public withRequest(req: V3Request): PactV3 {
-    let { body } = req
-    this.pact.addRequest(req, body)
+    this.pact.addRequest(req, req.body)
     return this
   }
 
@@ -191,8 +190,7 @@ export class PactV3 {
   }
 
   public willRespondWith(res: V3Response): PactV3 {
-    let { body } = res
-    this.pact.addResponse(res, body)
+    this.pact.addResponse(res, res.body)
     this.states = []
     return this
   }

--- a/src/v3/xml/xmlBuilder.ts
+++ b/src/v3/xml/xmlBuilder.ts
@@ -14,9 +14,9 @@ export class XmlBuilder {
     this.root = new XmlElement(rootElement)
   }
 
-  public build(callback: (doc: XmlElement) => void): XmlBuilder {
+  public build(callback: (doc: XmlElement) => void): string {
     callback(this.root)
 
-    return this
+    return JSON.stringify(this)
   }
 }


### PR DESCRIPTION
Fixes #633 

The current implementation serialises the req/res bodies to JSON, and then if the content type is JSON, processes the intermediate format to extract all matching rules and generators.

This means that matching rules and generators can't be used with other content types.

The fix: pass the body over to the Rust implementation as is, then if the body is an object, process it instead of using the content type.