### PR TITLE
docs: ignore-scripts would break the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Read [Getting started with Pact] for more information for beginners.
 ```
 npm i -S @pact-foundation/pact@latest
 ```
+Make sure the `ignore-scripts` option is disabled, pact uses npm scripts to download further dependencies. 
 
 ### Do Not Track
 


### PR DESCRIPTION
- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

using `ignore-scripts` option of npm or yarn breaks the installation because the pact standalone binara cannot be downloaded 
