### PR TITLE
fix: Error message with no pactBrokerUrl and no pactUrls

### DIFF
--- a/src/v3/verifier.spec.ts
+++ b/src/v3/verifier.spec.ts
@@ -1,0 +1,54 @@
+import * as mockery from 'mockery';
+
+import * as chai from 'chai';
+
+const MockNative = {
+  generate_datetime_string: () => '',
+  generate_regex_string: () => '',
+};
+mockery.registerMock('../../native/index.node', MockNative);
+
+// eslint-disable-next-line import/first
+import { VerifierV3 } from './verifier';
+
+const { expect } = chai;
+
+describe('V3 Verifier', () => {
+  describe('invalid configuration', () => {
+    it('returns an error when no provider name is given', () => {
+      const result = new VerifierV3({
+        logLevel: '',
+        provider: '',
+        providerBaseUrl: '',
+      }).verifyProvider();
+
+      return expect(result).to.eventually.be.rejectedWith(
+        Error,
+        'Provider name is required'
+      );
+    });
+    it('returns an error when no pactBrokerUrl and an empty list of pactUrls is given', () => {
+      const result = new VerifierV3({
+        logLevel: '',
+        provider: 'unitTest',
+        providerBaseUrl: '',
+        pactUrls: [],
+      }).verifyProvider();
+      return expect(result).to.eventually.be.rejectedWith(
+        Error,
+        'Either a list of pactUrls or a pactBrokerUrl must be provided'
+      );
+    });
+    it('returns an error when no pactBrokerUrl an no pactUrls is given', () => {
+      const result = new VerifierV3({
+        logLevel: '',
+        provider: 'unitTest',
+        providerBaseUrl: '',
+      }).verifyProvider();
+      return expect(result).to.eventually.be.rejectedWith(
+        Error,
+        'Either a list of pactUrls or a pactBrokerUrl must be provided'
+      );
+    });
+  });
+});

--- a/src/v3/verifier.ts
+++ b/src/v3/verifier.ts
@@ -66,7 +66,10 @@ export class VerifierV3 {
       if (!this.config.provider) {
         reject(new ConfigurationError('Provider name is required'));
       }
-      if (isEmpty(this.config.pactUrls) && !this.config.pactBrokerUrl) {
+      if (
+        (isEmpty(this.config.pactUrls) || !this.config.pactUrls) &&
+        !this.config.pactBrokerUrl
+      ) {
         reject(
           new ConfigurationError(
             'Either a list of pactUrls or a pactBrokerUrl must be provided'


### PR DESCRIPTION
- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

fixes #669
check if `this.config.pactUrls` is set at all before trying to run the `verify_provider` 