### PR TITLE
chore: avoid absolute imports

### DIFF
--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -4,8 +4,8 @@
  * but are fixed, to prevent contract invalidation after each run of the consumer test.
  */
 
-import { AnyJson, JsonMap } from 'common/jsonTypes';
 import { isFunction, isNil, isEmpty, isUndefined } from 'lodash';
+import { AnyJson, JsonMap } from '../common/jsonTypes';
 import MatcherError from '../errors/matcherError';
 
 // Note: The following regexes are Ruby formatted,

--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -1,4 +1,4 @@
-import { AnyJson } from 'common/jsonTypes';
+import { AnyJson } from '../common/jsonTypes';
 import { Matcher, AnyTemplate } from './matchers';
 
 /**

--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -4,7 +4,7 @@
 
 import { isEmpty, cloneDeep } from 'lodash';
 import serviceFactory from '@pact-foundation/pact-core';
-import { AnyJson } from 'common/jsonTypes';
+import { AnyJson } from './common/jsonTypes';
 import { extractPayload, AnyTemplate } from './dsl/matchers';
 import {
   Metadata,

--- a/src/v3/xml/xmlElement.ts
+++ b/src/v3/xml/xmlElement.ts
@@ -1,4 +1,4 @@
-import { Matcher } from 'v3/matchers';
+import { Matcher } from '../matchers';
 import { XmlNode } from './xmlNode';
 import { XmlText } from './xmlText';
 

--- a/src/v3/xml/xmlText.ts
+++ b/src/v3/xml/xmlText.ts
@@ -1,4 +1,4 @@
-import { Matcher } from 'v3/matchers';
+import { Matcher } from '../matchers';
 import { XmlNode } from './xmlNode';
 
 export class XmlText extends XmlNode {


### PR DESCRIPTION
Absolute imports can introduce problems for consumers which can be avoided using relative imports. Also relative imports align better with the general style used in pact-js

```
node_modules/@pact-foundation/pact/src/dsl/matchers.d.ts:6:25 - error TS2307: Cannot find module 'common/jsonTypes' or its corresponding type declarations.

6 import { AnyJson } from 'common/jsonTypes';
```