### PR TITLE
fix: Avoid exception when printing request.body

### DIFF
--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -102,8 +102,8 @@ function displayRequest(request: MismatchRequest, indent: string): string {
   }
 
   if (request.body) {
+    const body = JSON.stringify(request.body);
     output.push(
-      const body = JSON.stringify(request.body);
       `${indent}Body: ${body.substr(0, 20)}... (${
         body.length
       } length)`

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -103,8 +103,9 @@ function displayRequest(request: MismatchRequest, indent: string): string {
 
   if (request.body) {
     output.push(
-      `${indent}Body: ${request.body.substr(0, 20)}... (${
-        request.body.length
+      const body = JSON.stringify(request.body);
+      `${indent}Body: ${body.substr(0, 20)}... (${
+        body.length
       } length)`
     );
   }


### PR DESCRIPTION
When a request is not received we are supposed to get an error message saying "The following request was expected but not received", with the request printed immediately afterwards. However, if the request has a JSON body, we get an exception saying "TypeError: request.body.substr is not a function". The problem is that we need to first convert the JSON body to a string before we can apply the substr method to it (and similarly for the length property). This PR fixes that.