### PR TITLE
feat: reset consumer test state to enable re-use of PactV3 class

### DIFF
--- a/examples/nestjs-consumer/test/app.spec.ts
+++ b/examples/nestjs-consumer/test/app.spec.ts
@@ -21,8 +21,13 @@ pactWith(
     });
 
     // Alias flexible matchers for simplicity
-    const { eachLike, like, term, iso8601DateTimeWithMillis, extractPayload } =
-      Matchers;
+    const {
+      eachLike,
+      like,
+      term,
+      iso8601DateTimeWithMillis,
+      extractPayload,
+    } = Matchers;
 
     // Animal we want to match :)
     const suitor: Animal = {

--- a/examples/nestjs-provider/src/app.repository.ts
+++ b/examples/nestjs-provider/src/app.repository.ts
@@ -13,10 +13,10 @@ export class AppRepository {
   }
 
   public importData(): void {
-    const data = fs.readFileSync(
+    const data = (fs.readFileSync(
       path.resolve('./data/animal-data.json'),
       'utf-8'
-    ) as unknown as string;
+    ) as unknown) as string;
 
     JSON.parse(data).reduce((animal, value) => {
       value.id = animal + 1;

--- a/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
+++ b/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
@@ -5,8 +5,7 @@ import { AppRepository } from '../../src/app.repository';
 
 @Injectable()
 export class PactProviderConfigOptionsService
-  implements PactProviderOptionsFactory
-{
+  implements PactProviderOptionsFactory {
   public constructor(private readonly animalRepository: AppRepository) {}
 
   public createPactProviderOptions(): PactProviderOptions {

--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -2,7 +2,7 @@ const path = require('path');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const expect = chai.expect;
-const { PactV3, MatchersV3, XmlBuilder } = require('@pact-foundation/pact/v3');
+const { PactV3, MatchersV3, XmlBuilder } = require('../../../../dist/v3');
 const LOG_LEVEL = process.env.LOG_LEVEL || 'WARN';
 
 chai.use(chaiAsPromised);
@@ -87,6 +87,13 @@ describe('Pact V3', () => {
     availableAnimals,
   } = require('../consumer');
 
+  const provider = new PactV3({
+    consumer: 'Matching Service V3',
+    provider: 'Animal Profile Service V3',
+    dir: path.resolve(process.cwd(), 'pacts'),
+    cors: true,
+  });
+
   // Verify service client works as expected.
   //
   // Note that we don't call the consumer API endpoints directly, but
@@ -94,13 +101,6 @@ describe('Pact V3', () => {
   // we want to test the function that is calling the external service.
   describe('when a call to list all animals from the Animal Service is made', () => {
     describe('and the user is not authenticated', () => {
-      const provider = new PactV3({
-        consumer: 'Matching Service V3',
-        provider: 'Animal Profile Service V3',
-        dir: path.resolve(process.cwd(), 'pacts'),
-        cors: true,
-      });
-
       before(() =>
         provider
           .given('is not authenticated')
@@ -124,11 +124,6 @@ describe('Pact V3', () => {
     describe('and the user is authenticated', () => {
       describe('and there are animals in the database', () => {
         it('returns a list of animals', () => {
-          const provider = new PactV3({
-            consumer: 'Matching Service V3',
-            provider: 'Animal Profile Service V3',
-            dir: path.resolve(process.cwd(), 'pacts'),
-          });
           provider
             .given('is authenticated')
             .given('Has some animals')
@@ -160,12 +155,6 @@ describe('Pact V3', () => {
         });
 
         it('returns a filtered list of animals', () => {
-          const provider = new PactV3({
-            consumer: 'Matching Service V3',
-            provider: 'Animal Profile Service V3',
-            dir: path.resolve(process.cwd(), 'pacts'),
-            port: 1234,
-          });
           provider
             .given('is authenticated')
             .given('Has some animals')
@@ -214,11 +203,6 @@ describe('Pact V3', () => {
           });
         });
         it('returns a filtered list of animals (query containing chinese characters)', () => {
-          const provider = new PactV3({
-            consumer: 'Matching Service V3',
-            provider: 'Animal Profile Service V3',
-            dir: path.resolve(process.cwd(), 'pacts'),
-          });
           provider
             .given('is authenticated')
             .given('Has some animals')
@@ -269,11 +253,6 @@ describe('Pact V3', () => {
           });
         });
         it('returns a filtered list of animals (query containing devanagari characters)', () => {
-          const provider = new PactV3({
-            consumer: 'Matching Service V3',
-            provider: 'Animal Profile Service V3',
-            dir: path.resolve(process.cwd(), 'pacts'),
-          });
           provider
             .given('is authenticated')
             .given('Has some animals')
@@ -331,11 +310,6 @@ describe('Pact V3', () => {
     describe('and there is an animal in the DB with ID 100', () => {
       let responseBody = animalBodyExpectation;
       responseBody.id = 100;
-      const provider = new PactV3({
-        consumer: 'Matching Service V3',
-        provider: 'Animal Profile Service V3',
-        dir: path.resolve(process.cwd(), 'pacts'),
-      });
 
       before(() =>
         provider
@@ -367,12 +341,6 @@ describe('Pact V3', () => {
     });
 
     describe('and there no animals in the database', () => {
-      const provider = new PactV3({
-        consumer: 'Matching Service V3',
-        provider: 'Animal Profile Service V3',
-        dir: path.resolve(process.cwd(), 'pacts'),
-      });
-
       before(() =>
         provider
           .given('is authenticated')
@@ -400,12 +368,6 @@ describe('Pact V3', () => {
 
   describe('when a call to the Animal Service is made to retrieve a single animal in text by ID', () => {
     describe('and there is an animal in the DB with ID 100', () => {
-      const provider = new PactV3({
-        consumer: 'Matching Service V3',
-        provider: 'Animal Profile Service V3',
-        dir: path.resolve(process.cwd(), 'pacts'),
-      });
-
       before(() =>
         provider
           .given('is authenticated')
@@ -445,12 +407,6 @@ describe('Pact V3', () => {
   });
 
   describe('when a call to the Animal Service is made to create a new mate', () => {
-    const provider = new PactV3({
-      consumer: 'Matching Service V3',
-      provider: 'Animal Profile Service V3',
-      dir: path.resolve(process.cwd(), 'pacts'),
-    });
-
     before(() =>
       provider
         .given('is authenticated')
@@ -481,12 +437,6 @@ describe('Pact V3', () => {
   });
 
   describe('when a call to the Animal Service is made to create a new mate using form-data body', () => {
-    const provider = new PactV3({
-      consumer: 'Matching Service V3',
-      provider: 'Animal Profile Service V3',
-      dir: path.resolve(process.cwd(), 'pacts'),
-    });
-
     before(() =>
       provider
         .given('is authenticated')
@@ -522,12 +472,6 @@ describe('Pact V3', () => {
   });
 
   describe('when a call to the Animal Service is made to get animals in XML format', () => {
-    const provider = new PactV3({
-      consumer: 'Matching Service V3',
-      provider: 'Animal Profile Service V3',
-      dir: path.resolve(process.cwd(), 'pacts'),
-    });
-
     before(() =>
       provider
         .given('is authenticated')

--- a/examples/v3/provider-state-injected/consumer/transaction-service.test.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.test.js
@@ -2,17 +2,20 @@ const path = require('path');
 const transactionService = require('./transaction-service');
 const { PactV3, MatchersV3, XmlBuilder } = require('@pact-foundation/pact/v3');
 const { expect } = require('chai');
-const { string, integer, url2, regex, datetime, fromProviderState } =
-  MatchersV3;
+const {
+  string,
+  integer,
+  url2,
+  regex,
+  datetime,
+  fromProviderState,
+} = MatchersV3;
 
 describe('Transaction service - create a new transaction for an account', () => {
-  let provider;
-  beforeEach(() => {
-    provider = new PactV3({
-      consumer: 'TransactionService',
-      provider: 'AccountService',
-      dir: path.resolve(process.cwd(), 'pacts'),
-    });
+  const provider =  new PactV3({
+    consumer: 'TransactionService',
+    provider: 'AccountService',
+    dir: path.resolve(process.cwd(), 'pacts'),
   });
 
   it('queries the account service for the account details', () => {

--- a/examples/v3/provider-state-injected/consumer/transaction-service.test.js
+++ b/examples/v3/provider-state-injected/consumer/transaction-service.test.js
@@ -12,7 +12,7 @@ const {
 } = MatchersV3;
 
 describe('Transaction service - create a new transaction for an account', () => {
-  const provider =  new PactV3({
+  const provider = new PactV3({
     consumer: 'TransactionService',
     provider: 'AccountService',
     dir: path.resolve(process.cwd(), 'pacts'),

--- a/examples/v3/todo-consumer/test/consumer.spec.js
+++ b/examples/v3/todo-consumer/test/consumer.spec.js
@@ -2,8 +2,15 @@ const path = require('path');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { PactV3, MatchersV3, XmlBuilder } = require('@pact-foundation/pact/v3');
-const { string, eachLike, integer, boolean, atLeastOneLike, timestamp, regex } =
-  MatchersV3;
+const {
+  string,
+  eachLike,
+  integer,
+  boolean,
+  atLeastOneLike,
+  timestamp,
+  regex,
+} = MatchersV3;
 
 const TodoApp = require('../src/todo');
 
@@ -12,16 +19,16 @@ const expect = chai.expect;
 chai.use(chaiAsPromised);
 
 describe('Pact V3', () => {
+  const provider = new PactV3({
+    consumer: 'TodoApp',
+    provider: 'TodoServiceV3',
+    dir: path.resolve(process.cwd(), 'pacts'),
+  });
+
   context('when there are a list of projects', () => {
     describe('and there is a valid user session', () => {
       describe('with JSON request', () => {
-        let provider;
         before(() => {
-          provider = new PactV3({
-            consumer: 'TodoApp',
-            provider: 'TodoServiceV3',
-            dir: path.resolve(process.cwd(), 'pacts'),
-          });
           provider
             .given('i have a list of projects')
             .uponReceiving('a request for projects')
@@ -72,11 +79,6 @@ describe('Pact V3', () => {
 
     describe('with XML requests', () => {
       before(() => {
-        provider = new PactV3({
-          consumer: 'TodoApp',
-          provider: 'TodoServiceV3',
-          dir: path.resolve(process.cwd(), 'pacts'),
-        });
         provider
           .given('i have a list of projects')
           .uponReceiving('a request for projects in XML')
@@ -151,11 +153,6 @@ describe('Pact V3', () => {
 
     describe('with image uploads', () => {
       before(() => {
-        provider = new PactV3({
-          consumer: 'TodoApp',
-          provider: 'TodoServiceV3',
-          dir: path.resolve(process.cwd(), 'pacts'),
-        });
         provider
           .given('i have a project', { id: '1001', name: 'Home Chores' })
           .uponReceiving('a request to store an image against the project')

--- a/src/dsl/verifier/proxy/stateHandler/stateHandler.ts
+++ b/src/dsl/verifier/proxy/stateHandler/stateHandler.ts
@@ -3,12 +3,13 @@ import express from 'express';
 import { ProxyOptions, ProviderState } from '../types';
 import { setupStates } from './setupStates';
 
-export const createProxyStateHandler =
-  (config: ProxyOptions) =>
-  (req: express.Request, res: express.Response): Promise<express.Response> => {
-    const message: ProviderState = req.body;
+export const createProxyStateHandler = (config: ProxyOptions) => (
+  req: express.Request,
+  res: express.Response
+): Promise<express.Response> => {
+  const message: ProviderState = req.body;
 
-    return setupStates(message, config)
-      .then((data) => res.json(data))
-      .catch((e) => res.status(500).send(e));
-  };
+  return setupStates(message, config)
+    .then((data) => res.json(data))
+    .catch((e) => res.status(500).send(e));
+};

--- a/src/dsl/verifier/proxy/tracer.ts
+++ b/src/dsl/verifier/proxy/tracer.ts
@@ -35,34 +35,37 @@ const removeEmptyRequestProperties = (req: express.Request) =>
     identity
   );
 
-export const createResponseTracer =
-  (): express.RequestHandler => (_, res, next) => {
-    const [oldWrite, oldEnd] = [res.write, res.end];
-    const chunks: Buffer[] = [];
+export const createResponseTracer = (): express.RequestHandler => (
+  _,
+  res,
+  next
+) => {
+  const [oldWrite, oldEnd] = [res.write, res.end];
+  const chunks: Buffer[] = [];
 
-    res.write = (chunk: Parameters<typeof res.write>[0]) => {
+  res.write = (chunk: Parameters<typeof res.write>[0]) => {
+    chunks.push(Buffer.from(chunk));
+    return oldWrite.apply(res, [chunk]);
+  };
+
+  res.end = (chunk: Parameters<typeof res.write>[0]) => {
+    if (chunk) {
       chunks.push(Buffer.from(chunk));
-      return oldWrite.apply(res, [chunk]);
-    };
-
-    res.end = (chunk: Parameters<typeof res.write>[0]) => {
-      if (chunk) {
-        chunks.push(Buffer.from(chunk));
-      }
-      const body = Buffer.concat(chunks).toString('utf8');
-      logger.debug(
-        removeEmptyResponseProperties(body, res),
-        'outgoing response'
-      );
-      oldEnd.apply(res, [chunk]);
-    };
-    if (typeof next === 'function') {
-      next();
     }
+    const body = Buffer.concat(chunks).toString('utf8');
+    logger.debug(removeEmptyResponseProperties(body, res), 'outgoing response');
+    oldEnd.apply(res, [chunk]);
   };
-
-export const createRequestTracer =
-  (): express.RequestHandler => (req, _, next) => {
-    logger.debug(removeEmptyRequestProperties(req), 'incoming request');
+  if (typeof next === 'function') {
     next();
-  };
+  }
+};
+
+export const createRequestTracer = (): express.RequestHandler => (
+  req,
+  _,
+  next
+) => {
+  logger.debug(removeEmptyRequestProperties(req), 'incoming request');
+  next();
+};

--- a/src/dsl/verifier/verifier.spec.ts
+++ b/src/dsl/verifier/verifier.spec.ts
@@ -106,7 +106,7 @@ describe('Verifier', () => {
     describe('when no configuration has been given', () => {
       it('fails with an error', () =>
         expect(
-          () => new Verifier(undefined as unknown as VerifierOptions)
+          () => new Verifier((undefined as unknown) as VerifierOptions)
         ).to.throw());
     });
 

--- a/src/httpPact.spec.ts
+++ b/src/httpPact.spec.ts
@@ -43,7 +43,7 @@ describe('Pact', () => {
   });
 
   beforeEach(() => {
-    pact = Object.create(Pact.prototype) as any as Pact;
+    pact = (Object.create(Pact.prototype) as any) as Pact;
     pact.opts = fullOpts;
   });
 

--- a/src/messageProviderPact.spec.ts
+++ b/src/messageProviderPact.spec.ts
@@ -70,9 +70,9 @@ describe('MesageProvider', () => {
   describe('#setupVerificationHandler', () => {
     describe('when their is a valid setup', () => {
       it('creates a valid express handler', (done) => {
-        const setupVerificationHandler = (
-          provider as any
-        ).setupVerificationHandler.bind(provider)();
+        const setupVerificationHandler = (provider as any).setupVerificationHandler.bind(
+          provider
+        )();
         const req = { body: successfulMessage };
         const res = {
           json: () => done(), // Expect a response
@@ -83,9 +83,9 @@ describe('MesageProvider', () => {
     });
     describe('when their is an invalid setup', () => {
       it('creates a valid express handler that rejects the message', (done) => {
-        const setupVerificationHandler = (
-          provider as any
-        ).setupVerificationHandler.bind(provider)();
+        const setupVerificationHandler = (provider as any).setupVerificationHandler.bind(
+          provider
+        )();
         const req = { body: nonExistentMessage };
         const res = {
           status: (status: number) => {
@@ -163,9 +163,9 @@ describe('MesageProvider', () => {
   });
   describe('#setupProxyApplication', () => {
     it('returns a valid express app', () => {
-      const setupProxyApplication = (
-        provider as any
-      ).setupProxyApplication.bind(provider);
+      const setupProxyApplication = (provider as any).setupProxyApplication.bind(
+        provider
+      );
       expect(setupProxyApplication().listen).to.be.a('function');
     });
   });

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -155,12 +155,7 @@ export class PactV3 {
 
   constructor(opts: PactV3Options) {
     this.opts = opts;
-    this.pact = new PactNative.Pact(
-      opts.consumer,
-      opts.provider,
-      pactPackageVersion,
-      omit(['consumer', 'provider', 'dir'], opts)
-    );
+    this.setup();
   }
 
   public given(providerState: string, parameters?: JsonMap): PactV3 {
@@ -272,9 +267,22 @@ export class PactV3 {
         })
         .finally(() => {
           this.pact.shutdownTest(result);
+          this.setup();
         });
     }
     this.pact.shutdownTest(result);
+    this.setup();
     return Promise.reject(result.testError);
+  }
+
+  // reset the internal state
+  // (this.pact cannot be re-used between tests)
+  private setup() {
+    this.pact = new PactNative.Pact(
+      this.opts.consumer,
+      this.opts.provider,
+      pactPackageVersion,
+      omit(['consumer', 'provider', 'dir'], this.opts)
+    );
   }
 }

--- a/src/v3/verifier.ts
+++ b/src/v3/verifier.ts
@@ -122,8 +122,9 @@ export class VerifierV3 {
     // This is just too messy to do on the rust side. neon-serde would have helped, but appears unmaintained
     // and is currently incompatible
     if (this.config.consumerVersionSelectors) {
-      config.consumerVersionSelectorsString =
-        this.config.consumerVersionSelectors.map((s) => JSON.stringify(s));
+      config.consumerVersionSelectorsString = this.config.consumerVersionSelectors.map(
+        (s) => JSON.stringify(s)
+      );
     }
 
     if (!this.config.provider) {


### PR DESCRIPTION
Wipes the internal state between test runs to enable re-use of the provider.

Not thread safe (it wasn't before), but if you want to run in parallel you can still create multiple providers as per what is currently the case, and the pact will be merged.