### PR TITLE
docs: update readme and examples to use providerVersionTags and consumerVersionTags instead of tag (singular)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ new Verifier(opts).verifyProvider().then(function () {
 | `pactBrokerUrl`             | false     | string                         | Base URL of the Pact Broker from which to retrieve the pacts. Required if `pactUrls` not given.                                                       |
 | `provider`                  | false     | string                         | Name of the provider if fetching from a Broker                                                                                                        |
 | `consumerVersionSelectors`  | false     | ConsumerVersionSelector\|array | Using [Selectors](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/) is a way we specify which pacticipants and versions we want to use when configuring verifications. |
-| `consumerVersionTag`        | false     | string\|array                  | Retrieve the latest pacts with given tag(s)                                                                                                           |
-| `providerVersionTag`        | false     | string\|array                  | Tag(s) to apply to the provider application                                                                                                           |
+| `consumerVersionTags`        | false     | string\|array                  | Retrieve the latest pacts with given tag(s)                                                                                                           |
+| `providerVersionTags`        | false     | string\|array                  | Tag(s) to apply to the provider application                                                                                                           |
 | `includeWipPactsSince`      | false     | string                         | Includes pact marked as WIP since this date. String in the format %Y-%m-%d or %Y-%m-%dT%H:%M:%S.000%:z                                                |
 | `pactUrls`                  | false     | array                          | Array of local pact file paths or HTTP-based URLs. Required if _not_ using a Pact Broker.                                                             |
 | `providerStatesSetupUrl`    | false     | string                         | Deprecated (use URL to send PUT requests to setup a given provider state                                                                              |
@@ -346,7 +346,7 @@ To dynamically retrieve pacts from a Pact Broker for a provider, provide the bro
 let opts = {
   pactBroker: "http://my-broker",
   provider: "Animal Profile Service",
-  consumerVersionTag: ["master", "prod"],
+  consumerVersionTags: ["master", "test", "prod"],
 }
 ```
 
@@ -364,7 +364,7 @@ To publish the verification results back to the Pact Broker, you need to enable 
 let opts = {
   publishVerificationResult: true, //generally you'd do something like `process.env.CI === 'true'`
   providerVersion: "version", //recommended to be the git sha
-  providerVersionTag: "tag", //optional, recommended to be the git branch
+  providerVersionTags: ["tag"], //optional, recommended to be the git branch
 }
 ```
 
@@ -586,7 +586,7 @@ To publish the verification results back to the Pact Broker, you need to enable 
 let opts = {
   publishVerificationResult: true, //recommended to only publish from CI by setting the value to `process.env.CI === 'true'`
   providerVersion: "version", //recommended to be the git sha eg. process.env.MY_CI_COMMIT
-  providerVersionTag: "tag", //optional, recommended to be the git branch eg. process.env.MY_CI_BRANCH
+  providerVersionTags: ["tag"], //optional, recommended to be the git branch eg. process.env.MY_CI_BRANCH
 }
 ```
 

--- a/examples/e2e/test/provider.spec.js
+++ b/examples/e2e/test/provider.spec.js
@@ -58,10 +58,10 @@ describe("Pact Verification", () => {
       pactBrokerUrl: "https://test.pact.dius.com.au/",
 
       // Fetch from broker with given tags
-      consumerVersionTag: ["prod"],
+      consumerVersionTags: ["master", "test", "prod"],
 
-      // Tag provider with given tags
-      providerVersionTag: ["prod"],
+      // Tag provider version with given tags
+      providerVersionTags: ["master"], // in real code, this would be dynamically set by process.env.GIT_BRANCH
 
       // Find _all_ pacts (not just latest) with tag prod
       //   consumerVersionSelectors: [{

--- a/examples/graphql/src/provider.spec.ts
+++ b/examples/graphql/src/provider.spec.ts
@@ -27,7 +27,7 @@ describe("Pact Verification", () => {
       // If you use git tags, then you can use @pact-foundation/absolute-version as we do here.
       providerVersion: versionFromGitTag(),
       publishVerificationResult: true,
-      consumerVersionTags: ["prod"],
+      consumerVersionTags: ["master", "test", "prod"],
     }
 
     return new Verifier(opts).verifyProvider().then(output => {

--- a/examples/messages/provider/message-provider.spec.ts
+++ b/examples/messages/provider/message-provider.spec.ts
@@ -29,7 +29,7 @@ describe("Message provider tests", () => {
     pactBrokerUsername: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
     pactBrokerPassword: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
     publishVerificationResult: true,
-    consumerVersionTags: ["prod"],
+    consumerVersionTags: ["master", "test", "prod"],
   })
 
   describe("send a dog event", () => {

--- a/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
+++ b/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
@@ -51,8 +51,8 @@ export class PactProviderConfigOptionsService
 
       // Fetch pacts from broker
       pactBrokerUrl: "https://test.pact.dius.com.au/",
-      consumerVersionTags: ["prod"],
-      providerVersionTags: ["prod"],
+      consumerVersionTags: ["master", "test", "prod"],
+      providerVersionTags: ["master"], // in real code, this would be dynamically set by process.env.GIT_BRANCH
       enablePending: true,
       pactBrokerUsername: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
       pactBrokerPassword: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",

--- a/examples/serverless/provider/message-provider.spec.js
+++ b/examples/serverless/provider/message-provider.spec.js
@@ -25,7 +25,7 @@ describe("Message provider tests", () => {
     pactBrokerPassword: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
     publishVerificationResult: true,
 
-    consumerVersionTags: ["latest"],
+    consumerVersionTags: ["master", "test", "prod"],
   })
 
   describe("send an event", () => {


### PR DESCRIPTION
Also updates the tag values to use best practice examples.