### PR TITLE
fix: using relative import for provider, fixes problems with intellisense in vscode

### DIFF
--- a/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
+++ b/examples/nestjs-provider/test/pact/pact-provider-config-options.service.ts
@@ -28,24 +28,24 @@ export class PactProviderConfigOptionsService
           this.animalRepository.clear();
           token = '1234';
 
-          return 'Animals removed to the db';
+          return { description: 'Animals removed to the db' };
         },
         'Has some animals': async () => {
           token = '1234';
           this.animalRepository.importData();
 
-          return 'Animals added to the db';
+          return { description: 'Animals added to the db' };
         },
         'Has an animal with ID 1': async () => {
           token = '1234';
           this.animalRepository.importData();
 
-          return 'Animals added to the db';
+          return { description: 'Animals added to the db' };
         },
         'is not authenticated': async () => {
           token = '';
 
-          return 'Invalid bearer token generated';
+          return { description: 'Invalid bearer token generated' };
         },
       },
 

--- a/src/v3/verifier.ts
+++ b/src/v3/verifier.ts
@@ -1,9 +1,9 @@
 import { isEmpty } from 'ramda';
-import { ProxyOptions, StateHandlers } from 'dsl/verifier/proxy/types';
 
 import * as express from 'express';
 import * as http from 'http';
 import * as url from 'url';
+import { ProxyOptions, StateHandlers } from '../dsl/verifier/proxy/types';
 import { localAddresses } from '../common/net';
 import { createProxy, waitForServerReady } from '../dsl/verifier/proxy';
 


### PR DESCRIPTION
Fixes vscode intellisense by using a relative import instead of an absolute one.