### PR TITLE
fix: support null values in matchers

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -618,6 +618,23 @@ describe("Matcher", () => {
         })
       })
 
+      describe("when given an object with null values", () => {
+        const object = {
+          some: "data",
+          more: null,
+          an: [null],
+          someObject: {
+            withData: true,
+            withNumber: 1,
+            andNull: null,
+          },
+        }
+
+        it("returns just that object", () => {
+          expect(extractPayload(object)).to.deep.eql(object)
+        })
+      })
+
       describe("when given an object with some matchers", () => {
         const someMatchers = {
           some: somethingLike("data"),

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -296,7 +296,7 @@ export function extractPayload(value: any): any {
     return value.map(extractPayload)
   }
 
-  if (typeof value === "object") {
+  if (value !== null && typeof value === "object") {
     return Object.keys(value).reduce(
       (acc: object, propName: string) => ({
         ...acc,


### PR DESCRIPTION
## Description:
There is a bug in recent versions that cause a `TypeError` when the content of the payload to verify has `null` values in it

## How to reproduce:
Using the example of a [consumer in the README](https://github.com/pact-foundation/pact-js#consumer), use an object such as:
```javascript
.withContent({
          id: like(1),
          name: null, // <--- null value
          type: term({ generate: "bulldog", matcher: "^(bulldog|sheepdog)$" }),
        })
```

## How to fix:
The function `extractPayload` of _matchers.ts_ is checking if the `value` has type `object` to reduce it, but `null` is considered an object by javascript (again the magic of JS 🥸🎉), so it throws an exception when doing `Object.keys(null)`

I just added a null check and covered the scenario with an additional test