### PR TITLE
Fix interaction response status type

### DIFF
--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -22,7 +22,7 @@ export interface RequestOptions {
 }
 
 export interface ResponseOptions {
-  status: number | MatcherResult
+  status: number
   headers?: { [name: string]: string | MatcherResult }
   body?: any
 }


### PR DESCRIPTION

Currently, it is allowed to write

```ts
willRespondWith: {
  status: Matchers.like(200)
},
```

but the result will always be 500 as Matchers are not supported for the response status.