### PR TITLE
fix: All options are now passed down to pact-core in consumer pacts, allowing usage of the undocumented `monkeypatch` option

### DIFF
--- a/src/httpPact.spec.ts
+++ b/src/httpPact.spec.ts
@@ -35,6 +35,7 @@ describe("Pact", () => {
     spec: 2,
     cors: false,
     pactfileWriteMode: "overwrite",
+    monkeypatch: "/path/to/monkeypatch.rb",
   } as PactOptionsComplete
 
   before(() => {
@@ -140,6 +141,7 @@ describe("Pact", () => {
           spec: 2,
           cors: false,
           pactfileWriteMode: "overwrite",
+          monkeypatch: "/path/to/monkeypatch.rb",
         })
       })
     })

--- a/src/httpPact.ts
+++ b/src/httpPact.ts
@@ -8,7 +8,7 @@ import { isPortAvailable } from "./common/net"
 import logger, { traceHttpInteractions, setLogLevel } from "./common/logger"
 import { MockService } from "./dsl/mockService"
 import { LogLevel, PactOptions, PactOptionsComplete } from "./dsl/options"
-import { Server } from "@pact-foundation/pact-node/src/server"
+import { Server, ServerOptions } from "@pact-foundation/pact-node/src/server"
 import VerificationError from "./errors/verificationError"
 import ConfigurationError from "./errors/configurationError"
 
@@ -278,19 +278,9 @@ export class Pact {
 
   private createServer(config: PactOptions) {
     this.server = serviceFactory.createServer({
-      consumer: this.opts.consumer,
-      cors: this.opts.cors,
-      dir: this.opts.dir,
-      host: this.opts.host,
-      log: this.opts.log,
-      pactFileWriteMode: this.opts.pactfileWriteMode,
+      timeout: 30000,
+      ...this.opts,
       port: config.port, // allow to be undefined
-      provider: this.opts.provider,
-      spec: this.opts.spec,
-      ssl: this.opts.ssl,
-      sslcert: this.opts.sslcert,
-      sslkey: this.opts.sslkey,
-      timeout: this.opts.timeout || 30000,
-    })
+    } as ServerOptions)
   }
 }


### PR DESCRIPTION
This option can be used to monkey-patch the pact-mock-server. This addresses part of [issue #123](https://github.com/pact-foundation/pact-js/issues/123), which was originally closed due to the fact that option first had to be added to pact-node, which has since been done.

I am using jest-pact, and I want to be able to provide a monkeypatch, in order to increase the max URI length for the pact server, as it is [hard-coded to 2083 characters in WEBrick](https://github.com/ruby/webrick/blob/563b8309976065ba008430f2f1483d5bc3a713cf/lib/webrick/httprequest.rb#L446), but I want to increase that limit for my tests.

After this change, I can create a file webrick.rb
```rb
WEBrick::HTTPRequest.const_set('MAX_URI_LENGTH', 10000)
```

Then I can provide the monkeypatch option to jest-pact, to point to that file:
```js
import path from 'path';
import { pactWith } from 'jest-pact';

pactWith(
  {
    consumer: 'My consumer',
    provider: 'My provider,
    monkeypatch: path.join(__dirname, '../../monkeypatch/webrick.rb')
  },
  (provider) => { ... }
);
```