### PR TITLE
fix: throw an error when pact spec version is not set to 2

### DIFF
--- a/src/httpPact.ts
+++ b/src/httpPact.ts
@@ -65,6 +65,12 @@ export class Pact {
       throw new ConfigurationError("You must specify a Provider for this pact.")
     }
 
+    if (this.opts.spec !== 2) {
+      throw new ConfigurationError(
+        "Pact-js currently only supports pact spec version 2. If you need a higher version of the pact specification, you can try the beta. See instructions here: https://github.com/pact-foundation/pact-js#pact-js-v3"
+      )
+    }
+
     setLogLevel(this.opts.logLevel as LogLevel)
     serviceFactory.logLevel(this.opts.logLevel)
 

--- a/src/pact-web.ts
+++ b/src/pact-web.ts
@@ -74,6 +74,10 @@ export class PactWeb {
 
     this.opts = { ...defaults, ...config } as PactWebOptionsComplete
 
+    if (this.opts.spec !== 2) {
+      throw new Error("Pact-web only supports pact spec version 2")
+    }
+
     console.info(
       `Setting up Pact using mock service on port: "${this.opts.port}"`
     )


### PR DESCRIPTION
- [X] `npm run dist` works locally (this will run tests, lint and build)
- [X] Commit messages are ready to go in the changelog (see below for details)
- [X] PR template filled in (see below for details)

### PR Template

This PR throws an error in both pact-js and pact-web when a spec version other than 2 is used to create an http pact.

It's one way to fix #838 - the other, of course, would be to release the v3 compatibility.