### PR TITLE
fix: Add support for state params to MessageProviderPact (#372)

### DIFF
--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -12,19 +12,29 @@ export interface Metadata {
 }
 
 /**
+ * Defines a state a provider must be in.
+ */
+export interface ProviderState {
+  name: string;
+  params?: {
+    [name: string]: string;
+  };
+}
+
+/**
  * A Message is an asynchronous Interaction, sent via a Provider
  *
  * @module Message
  */
 export interface Message {
-  providerStates?: [{ name: string }];
+  providerStates?: ProviderState[];
   description?: string;
   metadata?: Metadata;
   contents: AnyTemplate;
 }
 
 export interface ConcreteMessage {
-  providerStates?: [{ name: string }];
+  providerStates?: ProviderState[];
   description?: string;
   metadata?: Metadata;
   contents: AnyJson;
@@ -36,7 +46,7 @@ export interface ConcreteMessage {
  * @module Message
  */
 export interface MessageDescriptor {
-  providerStates?: [{ name: string }];
+  providerStates?: ProviderState[];
   description: string;
   metadata?: Metadata;
 }
@@ -76,5 +86,8 @@ export interface MessageProviders {
 }
 
 export interface StateHandlers {
-  [name: string]: (state: string) => Promise<unknown>;
+  [name: string]: (
+    state: string,
+    params?: { [name: string]: string }
+  ) => Promise<unknown>;
 }

--- a/src/messageProviderPact.spec.ts
+++ b/src/messageProviderPact.spec.ts
@@ -48,6 +48,8 @@ describe('MesageProvider', () => {
       provider: 'myprovider',
       stateHandlers: {
         'some state': () => Promise.resolve('yay'),
+        'some state with params': (name, params) =>
+          Promise.resolve(`name: ${name}, params: ${JSON.stringify(params)}`),
       },
     });
   });
@@ -122,10 +124,22 @@ describe('MesageProvider', () => {
   describe('#setupStates', () => {
     describe('when given a handler that exists', () => {
       it('returns values of all resolved handlers', () => {
-        const findStateHandler = (provider as any).setupStates.bind(provider);
+        const setupStates = (provider as any).setupStates.bind(provider);
+        return expect(setupStates(successfulMessage)).to.eventually.deep.equal([
+          'yay',
+        ]);
+      });
+      it('passes params to the handler', () => {
+        const setupStates = (provider as any).setupStates.bind(provider);
         return expect(
-          findStateHandler(successfulMessage)
-        ).to.eventually.deep.equal(['yay']);
+          setupStates({
+            providerStates: [
+              { name: 'some state with params', params: { foo: 'bar' } },
+            ],
+          })
+        ).to.eventually.deep.equal([
+          'name: some state with params, params: {"foo":"bar"}',
+        ]);
       });
     });
     describe('when given a state that does not have a handler', () => {

--- a/src/messageProviderPact.ts
+++ b/src/messageProviderPact.ts
@@ -166,7 +166,7 @@ export class MessageProviderPact {
           : null;
 
         if (handler) {
-          promises.push(handler(state.name));
+          promises.push(handler(state.name, state.params));
         } else {
           logger.warn(`no state handler found for "${state.name}", ignoring`);
         }


### PR DESCRIPTION
This PR adds support for passing the params of providerStates to the `stateHandlers` of a `MessageProviderPact`.
