### PR TITLE
chore: reference source file by relative path

### DIFF
--- a/src/httpPact/index.ts
+++ b/src/httpPact/index.ts
@@ -26,7 +26,7 @@ import { SpecificationVersion } from '../v3';
 import { version as pactPackageVersion } from '../../package.json';
 import { generateMockServerError } from '../v3/display';
 import { numberToSpec } from '../common/spec';
-import { MockService } from 'dsl/mockService';
+import { MockService } from '../dsl/mockService';
 import { setRequestDetails, setResponseDetails } from './ffi';
 
 const logErrorNoMockServer = () => {


### PR DESCRIPTION
### PR Template

Fix an issue where TS is looking for a module named `dsl/mockService` and fails to find it. By making the path relative it stops complaining.