### PR TITLE
fix: dsl/verifier - express import typescript error

### DIFF
--- a/src/dsl/verifier/proxy/types.ts
+++ b/src/dsl/verifier/proxy/types.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import * as express from 'express';
 import { LogLevel } from '../../options';
 import { JsonMap, AnyJson } from '../../../common/jsonTypes';
 


### PR DESCRIPTION
Resolves https://github.com/pact-foundation/jest-pact/runs/7642886870?check_suite_focus=true#step:4:128

```
Error: node_modules/@pact-foundation/pact/src/dsl/verifier/proxy/types.d.ts(1,8): error TS1259: Module '"/Users/runner/work/jest-pact/jest-pact/node_modules/@types/express/index"' can only be default-imported using the 'esModuleInterop' flag
```

import could also change to `import { RequestHandler } from 'express';` as that is the only import used in the file

https://github.com/pact-foundation/pact-js/blob/60fa69f139e65000edcd28b1487bf372f338a59d/src/dsl/verifier/proxy/types.ts#L47