### PR TITLE
feat: port extractPayload function from 9.x

### DIFF
--- a/docs/migrations/9-10.md
+++ b/docs/migrations/9-10.md
@@ -199,6 +199,9 @@ provider
     });
 ```
 
+#### Other
+* The `extractPayload` function on the matchers has been renamed `reify` in [v3] matchers. The old name (`extractPayload`) is still available as an alias, but might be deprecated in the future.
+
 [CLI]: https://docs.pact.io/implementation_guides/cli/
 [v2]: https://github.com/pact-foundation/pact-specification/tree/version-3/
 [v3]: https://github.com/pact-foundation/pact-specification/tree/version-2/


### PR DESCRIPTION
The function is called `reify` in 10.x, and aliased as `extractPayload`
for backwards compatibility.

[Slack discussion](https://pact-foundation.slack.com/archives/C5F4KFKR8/p1660042113955029) for context.