### PR TITLE
docs(migration): Correct migration guide

### DIFF
--- a/docs/migrations/9-10.md
+++ b/docs/migrations/9-10.md
@@ -34,7 +34,8 @@ Alpine linux is currently [not supported](https://github.com/pact-foundation/pac
 
 ### Provider
 
-N/A - the interface is completely backwards compatible.
+* `customProviderHeaders` now expects an object of type `{ [key: string]: string }`, keyed by the header names, with values as the header values
+* `providerVersionBranch` has been renamed to `providerBranch`
 
 ### Messages
 


### PR DESCRIPTION

- [X] `npm run dist` works locally (this will run tests, lint and build)
- [X] Commit messages are ready to go in the changelog (see below for details)
- [X] PR template filled in (see below for details)

This PR corrects the migration guide with some information about changes to the provider verifier, following feedback from Adam Witko on slack: https://pact-foundation.slack.com/archives/C9VBGLUM9/p1660227998292199