### PR TITLE
Add prepare script to allow installation of this package via GH

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "postdist": "npm test",
     "predist": "npm run clean && npm run format:check && npm run lint",
     "release": "standard-version",
-    "test": "nyc --check-coverage --reporter=html --reporter=text-summary mocha"
+    "test": "nyc --check-coverage --reporter=html --reporter=text-summary mocha",
+    "prepare": "npm run compile"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@pact-foundation/pact",
   "version": "10.1.0",
   "description": "Pact for all things Javascript",
-  "main": "./src/index.js",
-  "types": "./src/index.d.ts",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "scripts": {
     "compile": "rimraf dist && tsc",
     "clean": "rimraf docs dist coverage .nyc_output logs pacts",


### PR DESCRIPTION
Based on https://github.com/npm/npm/issues/3055
npm introduced from v4 support for pre-compilation step on installing the package from node_modules or github directly. 

The reason this is needed is when people are trying to use their own forks of `pact-js` in their package.json directly. 
Right now, I hack it around with [special branch](https://github.com/Maxim-Filimonov/pact-js/tree/develop) which commits `dist` directory. But its a hack.

Its draft is that I don't want to put too much effort into figuring out how to test powershell(and sh) scripts **UNTIL** its confirmed that it this PR would be considered as valid change. 
They will need one extra addition - replace `'./dist'` with `''`.

@mefellows thoughts on this change, possible implications ?