### PR TITLE
chore: update e2e examples

### DIFF
--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -104,7 +104,7 @@ curl -H "Authorization: Bearer 1234" -X POST -H "Content-Type: application/json"
 #### GET /suggestions/:id
 
 ```
-curl -H "Authorization: Bearer 1234" -X GET http://localhost:8080/suggestions/1
+curl -X GET http://localhost:8080/suggestions/1
 ```
 
 ## Viewing contracts with the Pact Broker

--- a/examples/e2e/consumer.js
+++ b/examples/e2e/consumer.js
@@ -4,7 +4,7 @@ const server = express();
 
 const getApiEndpoint = () => process.env.API_HOST || 'http://localhost:8081';
 const authHeader = {
-  Authorization: 'Bearer token',
+  Authorization: 'Bearer 1234',
 };
 
 // Fetch animals who are currently 'available' from the
@@ -73,20 +73,27 @@ server.get('/suggestions/:animalId', (req, res) => {
     res.writeHead(400);
     res.end();
   }
-
-  request(`${getApiEndpoint()}/animals/${req.params.animalId}`, (err, r) => {
-    if (!err && r.statusCode === 200) {
-      suggestion(r.body).then((suggestions) => {
-        res.json(suggestions);
-      });
-    } else if (r && r.statusCode === 404) {
-      res.writeHead(404);
-      res.end();
-    } else {
+  request
+    .get(`${getApiEndpoint()}/animals/${req.params.animalId}`)
+    .set(authHeader)
+    .then((r) => {
+      if (r.statusCode === 200) {
+        suggestion(r.body).then((suggestions) => {
+          res.json(suggestions);
+        });
+      } else if (r && r.statusCode === 404) {
+        res.writeHead(404);
+        res.end();
+      } else {
+        res.writeHead(500);
+        res.end();
+      }
+    })
+    .catch((err) => {
+      console.log(err.message);
       res.writeHead(500);
       res.end();
-    }
-  });
+    });
 });
 
 module.exports = {

--- a/examples/e2e/consumerService.js
+++ b/examples/e2e/consumerService.js
@@ -1,5 +1,5 @@
 const { server } = require('./consumer.js');
 
 server.listen(8080, () => {
-  console.log('Animal Matching Service listening on http://localhots:8080');
+  console.log('Animal Matching Service listening on http://localhost:8080');
 });

--- a/examples/e2e/test/consumer.spec.js
+++ b/examples/e2e/test/consumer.spec.js
@@ -141,7 +141,12 @@ describe('Pact', () => {
             withRequest: {
               method: 'GET',
               path: '/animals/available',
-              headers: { Authorization: 'Bearer token' },
+              headers: {
+                Authorization: term({
+                  matcher: 'Bearer\\s[a-z0-9]+',
+                  generate: 'Bearer token',
+                }),
+              },
             },
             willRespondWith: {
               status: 200,
@@ -178,7 +183,12 @@ describe('Pact', () => {
           withRequest: {
             method: 'GET',
             path: term({ generate: '/animals/1', matcher: '/animals/[0-9]+' }),
-            headers: { Authorization: 'Bearer token' },
+            headers: {
+              Authorization: term({
+                matcher: 'Bearer\\s[a-z0-9]+',
+                generate: 'Bearer token',
+              }),
+            },
           },
           willRespondWith: {
             status: 200,
@@ -207,7 +217,12 @@ describe('Pact', () => {
           withRequest: {
             method: 'GET',
             path: '/animals/100',
-            headers: { Authorization: 'Bearer token' },
+            headers: {
+              Authorization: term({
+                matcher: 'Bearer\\s[a-z0-9]+',
+                generate: 'Bearer token',
+              }),
+            },
           },
           willRespondWith: {
             status: 404,

--- a/examples/nestjs-consumer/src/main.ts
+++ b/examples/nestjs-consumer/src/main.ts
@@ -6,7 +6,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(8080);
 
-  Logger.log('Animal Matching Service listening on http://localhots:8080');
+  Logger.log('Animal Matching Service listening on http://localhost:8080');
 }
 
 bootstrap();

--- a/examples/v3/e2e/README.md
+++ b/examples/v3/e2e/README.md
@@ -105,7 +105,7 @@ curl -H "Authorization: Bearer 1234" -X POST -H "Content-Type: application/json"
 #### GET /suggestions/:id
 
 ```
-curl -H "Authorization: Bearer 1234" -X GET http://localhost:8080/suggestions/1
+curl -X GET http://localhost:8080/suggestions/1
 ```
 
 ## Viewing contracts with the Pact Broker

--- a/examples/v3/e2e/consumer.js
+++ b/examples/v3/e2e/consumer.js
@@ -4,7 +4,7 @@ const server = express();
 
 const getApiEndpoint = () => process.env.API_HOST || 'http://localhost:8081';
 const authHeader = {
-  Authorization: 'Bearer token',
+  Authorization: 'Bearer 1234',
 };
 
 // Fetch animals who are currently 'available' from the
@@ -87,20 +87,27 @@ server.get('/suggestions/:animalId', (req, res) => {
     res.writeHead(400);
     res.end();
   }
-
-  request(`${getApiEndpoint()}/animals/${req.params.animalId}`, (err, r) => {
-    if (!err && r.statusCode === 200) {
-      suggestion(r.body).then((suggestions) => {
-        res.json(suggestions);
-      });
-    } else if (r && r.statusCode === 404) {
-      res.writeHead(404);
-      res.end();
-    } else {
+  request
+    .get(`${getApiEndpoint()}/animals/${req.params.animalId}`)
+    .set(authHeader)
+    .then((r) => {
+      if (r.statusCode === 200) {
+        suggestion(r.body).then((suggestions) => {
+          res.json(suggestions);
+        });
+      } else if (r && r.statusCode === 404) {
+        res.writeHead(404);
+        res.end();
+      } else {
+        res.writeHead(500);
+        res.end();
+      }
+    })
+    .catch((err) => {
+      console.log(err.message);
       res.writeHead(500);
       res.end();
-    }
-  });
+    });
 });
 
 const getAnimalsAsXML = (api = getApiEndpoint) => {

--- a/examples/v3/e2e/consumerService.js
+++ b/examples/v3/e2e/consumerService.js
@@ -1,5 +1,5 @@
 const { server } = require('./consumer.js');
 
 server.listen(8080, () => {
-  console.log('Animal Matching Service listening on http://localhots:8080');
+  console.log('Animal Matching Service listening on http://localhost:8080');
 });

--- a/examples/v3/e2e/test/consumer.spec.js
+++ b/examples/v3/e2e/test/consumer.spec.js
@@ -142,7 +142,7 @@ describe('Pact V3', () => {
             .withRequest({
               method: 'GET',
               path: '/animals/available',
-              headers: { Authorization: 'Bearer token' },
+              headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
             })
             .willRespondWith({
               status: 200,
@@ -174,7 +174,7 @@ describe('Pact V3', () => {
             .withRequest({
               method: 'GET',
               path: '/animals/available',
-              headers: { Authorization: 'Bearer token' },
+              headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
               query: {
                 first_name: 'Billy',
               },
@@ -228,7 +228,7 @@ describe('Pact V3', () => {
             .withRequest({
               method: 'GET',
               path: '/animals/available',
-              headers: { Authorization: 'Bearer token' },
+              headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
               query: {
                 first_name: '比利',
               },
@@ -282,7 +282,7 @@ describe('Pact V3', () => {
             .withRequest({
               method: 'GET',
               path: '/animals/available',
-              headers: { Authorization: 'Bearer token' },
+              headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
               query: {
                 first_name: 'बिल्ली',
               },
@@ -345,7 +345,7 @@ describe('Pact V3', () => {
           .withRequest({
             method: 'GET',
             path: regex('/animals/[0-9]+', '/animals/100'),
-            headers: { Authorization: 'Bearer token' },
+            headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
           })
           .willRespondWith({
             status: 200,
@@ -374,7 +374,7 @@ describe('Pact V3', () => {
           .withRequest({
             method: 'GET',
             path: regex('/animals/[0-9]+', '/animals/100'),
-            headers: { Authorization: 'Bearer token' },
+            headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
           })
           .willRespondWith({
             status: 404,
@@ -403,8 +403,9 @@ describe('Pact V3', () => {
           .withRequest({
             method: 'GET',
             path: regex('/animals/[0-9]+', '/animals/100'),
+
             headers: {
-              Authorization: 'Bearer token',
+              Authorization: regex('Bearer 1234', 'Bearer token'),
               Accept: 'text/plain',
             },
           })
@@ -513,7 +514,7 @@ describe('Pact V3', () => {
         .withRequest({
           method: 'GET',
           path: '/animals/available/xml',
-          headers: { Authorization: 'Bearer token' },
+          headers: { Authorization: regex('Bearer 1234', 'Bearer token') },
         })
         .willRespondWith({
           status: 200,

--- a/examples/v3/e2e/test/provider.spec.js
+++ b/examples/v3/e2e/test/provider.spec.js
@@ -86,7 +86,7 @@ describe('Pact Verification', () => {
       // pactUrls: [
       //   path.resolve(
       //     process.cwd(),
-      //     "./pacts/Matching Service V3-Animal Profile Service V3.json"
+      //     './pacts/Matching Service V3-Animal Profile Service V3.json'
       //   ),
       // ],
 


### PR DESCRIPTION
Yo,

Not sure if there is an issue with the e2e example codebases, both the v2/v3 versions.

1. README states hit the consumer service with a bearer token https://github.com/pact-foundation/pact-js/blob/master/examples/e2e/README.md#matching-service
1. The consumer codebase doesn't set an authHeader in the request to the provider codebase, so fails the request https://github.com/pact-foundation/pact-js/blob/e7d71e45a4a286c40fdf1ad8b49c6377da2540dc/examples/e2e/consumer.js#L77
1. The pact provider tests verify, because if an Authorization token is set, it is switched out with the correct token https://github.com/pact-foundation/pact-js/blob/master/examples/e2e/test/provider.spec.js#L31

In order to get this to work E2E,  I have 

1. Updated consumer codebase to send correct token
1. Added regex matchers to Auth header, so when correct header is sent, an example is encoded into the pact file, avoiding the user serialising sensitive data into the pact
1. Updated the README so if calling the consumer service, no auth header is required to be set.

Consumer pact tests are generated, provider is able to verify, and application works e2e when run.

Not sure if it is meant to be in this state, if so, we can add documentation to explain why it doesn't work e2e and the steps to resolve