### PR TITLE
build: No longer remove docs folder in clean step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./src/index.d.ts",
   "scripts": {
     "compile": "rimraf dist && tsc",
-    "clean": "rimraf docs dist coverage .nyc_output logs pacts",
+    "clean": "rimraf dist coverage .nyc_output logs pacts",
     "coverage": "nyc report --reporter=lcov",
     "dist": "tsc && copyfiles package.json ./dist",
     "lint": "eslint --config .eslintrc.json \"{src,test}/**/*.ts\"",


### PR DESCRIPTION

- [X] `npm run dist` works locally (this will run tests, lint and build)
- [X] Commit messages are ready to go in the changelog (see below for details)
- [X] PR template filled in (see below for details)

### PR Template

When preparing #946 I noticed that the `docs` folder was deleted following `npm run dist`. This is because they're deleted in the `clean` step - but, I don't see the docs being autogenerated anywhere.

My guess is that `docs` was left around from a previous iteration, and now that there is a docs folder again, it's not supposed to be removed by the build script.