### PR TITLE
fix reify logic relating to isMatcher function

### DIFF
--- a/src/v3/matchers.spec.ts
+++ b/src/v3/matchers.spec.ts
@@ -514,7 +514,7 @@ describe('V3 Matchers', () => {
   describe('#reify', () => {
     describe('when given an object with no matchers', () => {
       const object = {
-        some: 'data',
+        value: 'data', // field name of value should not be only determination of isMatcher()
         more: 'strings',
         an: ['array'],
         someObject: {
@@ -645,6 +645,21 @@ describe('V3 Matchers', () => {
         };
 
         expect(MatchersV3.reify(o)).to.deep.equal(expected);
+      });
+    });
+
+    describe('when given a matcher and field named "value"', () => {
+      it('should not be isMatcher"', () => {
+        const resultMatcher = MatchersV3.like({
+          a: 'b',
+          c: MatchersV3.atLeastOneLike({ value: '1', a: 'b', aa: 'bb' }),
+        });
+
+        const result = MatchersV3.reify(resultMatcher);
+        expect(result).to.deep.equal({
+          a: 'b',
+          c: [{ value: '1', a: 'b', aa: 'bb' }],
+        });
       });
     });
   });

--- a/src/v3/matchers.ts
+++ b/src/v3/matchers.ts
@@ -12,7 +12,11 @@ export interface Matcher<T> {
 }
 
 export function isMatcher(x: AnyTemplate): x is Matcher<AnyTemplate> {
-  return x != null && (x as Matcher<AnyTemplate>).value !== undefined;
+  return (
+    x != null &&
+    (x as Matcher<AnyTemplate>)['pact:matcher:type'] !== undefined &&
+    (x as Matcher<AnyTemplate>).value !== undefined
+  );
 }
 
 export type AnyTemplate =


### PR DESCRIPTION
isMatcher inadvertantly passes when a field name is 'value'

Thank you for making a pull request!

Pact-JS is built and maintained by developers like you, and we appreciate contributions very much. You are awesome!

Here is a short checklist to give your PR the best start:

_Everything above can be removed once checked_

- [ ] `npm run dist` works locally (this will run tests, lint and build)
- [ ] Commit messages are ready to go in the changelog (see below for details)
- [ ] PR template filled in (see below for details)

# Commit messages

Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that:

- commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements"
- commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features"

If you've made many commits that don't adhere to this style, we recommend squashing 
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change.

For more information please see CONTRIBUTING.md

_Everything above can be removed_

### PR Template

_Please describe what this PR is for, or link the issue that this PR fixes_

_You may add as much or as little context as you like here, whatever you think is right_

_Thanks again!_
