### PR TITLE
Fix/prevent absolute imports

### DIFF
--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -9,7 +9,7 @@ import {
 import { Matcher, matcherValueOrString } from '../dsl/matchers';
 import { forEachObjIndexed } from 'ramda';
 import { isArray } from 'util';
-import { AnyTemplate } from 'v3/matchers';
+import { AnyTemplate } from '../v3/matchers';
 
 // eslint-disable-next-line
 enum INTERACTION_PART {

--- a/src/v4/http/types.ts
+++ b/src/v4/http/types.ts
@@ -8,7 +8,7 @@ import {
   V3ProviderState,
   V3Request,
   V3Response,
-} from 'v3';
+} from '../../v3';
 import { AnyTemplate } from '../../v3/matchers';
 
 // TODO: do we alias all types to V4 or is this yicky??

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -1,6 +1,6 @@
-import { Metadata } from 'dsl/message';
-import { AnyTemplate } from 'v3/matchers';
 import { AnyJson, JsonMap } from '../../common/jsonTypes';
+import { Metadata } from '../../dsl/message';
+import { AnyTemplate } from '../../v3/matchers';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MessageContents {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "src",
     "sourceMap": true,
     "noLib": false,
     "noImplicitReturns": true,


### PR DESCRIPTION
This change detects any use of absolute paths such as `dsl/message`, resulting in a compilation failure.

VS Code (and hopefully other IDEs) will not auto-suggest/import these paths, and provide helpful hints such as the following if they are used:

<img width="1217" alt="Screen Shot 2022-11-14 at 10 33 11 pm" src="https://user-images.githubusercontent.com/53900/201650382-ec688370-5b23-4aaf-8965-f71ee0838960.png">

See also #974 