### PR TITLE
Fix double content type header graphql

### DIFF
--- a/src/dsl/graphql.spec.ts
+++ b/src/dsl/graphql.spec.ts
@@ -251,25 +251,4 @@ describe('GraphQLInteraction', () => {
       expect(json.request.body.query.getValue()).to.eq('{ hello }');
     });
   });
-
-  context('headers are not duplicated', () => {
-    describe('headers are properly cased', () => {
-      it('content-type header is properly cased', () => {
-        interaction.uponReceiving('a request');
-        interaction.withRequest({
-          path: '/graphql',
-          method: 'POST',
-        });
-        interaction.withOperation('query');
-        interaction.withQuery('{ hello }');
-        interaction.willRespondWith({
-          status: 200,
-          body: { data: {} },
-        });
-
-        const json: any = interaction.json();
-        expect(json.request.headers).to.deep.eq({ 'Content-Type': 'application/json' });
-      });
-    });
-  });
 });

--- a/src/dsl/graphql.spec.ts
+++ b/src/dsl/graphql.spec.ts
@@ -251,4 +251,25 @@ describe('GraphQLInteraction', () => {
       expect(json.request.body.query.getValue()).to.eq('{ hello }');
     });
   });
+
+  context('headers are not duplicated', () => {
+    describe('headers are properly cased', () => {
+      it('content-type header is properly cased', () => {
+        interaction.uponReceiving('a request');
+        interaction.withRequest({
+          path: '/graphql',
+          method: 'POST',
+        });
+        interaction.withOperation('query');
+        interaction.withQuery('{ hello }');
+        interaction.willRespondWith({
+          status: 200,
+          body: { data: {} },
+        });
+
+        const json: any = interaction.json();
+        expect(json.request.headers).to.deep.eq({ 'Content-Type': 'application/json' });
+      });
+    });
+  });
 });

--- a/src/dsl/graphql.spec.ts
+++ b/src/dsl/graphql.spec.ts
@@ -268,7 +268,9 @@ describe('GraphQLInteraction', () => {
         });
 
         const json: any = interaction.json();
-        expect(json.request.headers).to.deep.eq({ 'Content-Type': 'application/json' });
+        expect(json.request.headers).to.deep.eq({
+          'Content-Type': 'application/json',
+        });
       });
     });
   });

--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -118,7 +118,7 @@ export class GraphQLInteraction extends Interaction {
           },
           isUndefined
         ),
-        headers: { 'content-type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       },
       this.state.request

--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -118,7 +118,7 @@ export class GraphQLInteraction extends Interaction {
           },
           isUndefined
         ),
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'content-type': 'application/json' },
         method: 'POST',
       },
       this.state.request


### PR DESCRIPTION
- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

# Commit messages

### PR Template

Fixes pact generated with graphql with double "Content-Type" headers

The example at pact-js/examples/graphql when running npm run test:consumer it generates a Pact file with two “Content-Type” headers. Notice how one is in lower case “c” in “content”

```
{
  "consumer": {
    "name": "GraphQLConsumer"
  },
  "interactions": [
    {
      "description": "a hello request",
      "request": {
        "body": {
          "operationName": "HelloQuery",
          "query": "\n          query HelloQuery {\n            hello\n          }\n        ",
          "variables": {
            "foo": "bar"
          }
        },
        "headers": {
          "Content-Type": "application/json",
          "content-type": "application/json"
        },
```

