### PR TITLE
fix: Export `VerifierOptions` as a root export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export * from './dsl/message';
  * @static
  */
 export * from './dsl/verifier/verifier';
+export { VerifierOptions } from './dsl/verifier/types';
 
 /**
  * Exposes {@link GraphQL}


### PR DESCRIPTION
- [X] `npm run dist` works locally (this will run tests, lint and build)
- [X] Commit messages are ready to go in the changelog (see below for details)
- [X] PR template filled in (see below for details)

### PR Template

While looking at https://github.com/pact-foundation/nestjs-pact/pull/17  , I noticed that one of the breaking changes in V10 was that `VerifierOptions` is now deeply imported. This PR fixes that by exporting it at the root again.