### PR TITLE
chore: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Watch our [series](https://www.youtube.com/playlist?list=PLwy9Bnco-IpfZ72VQ7hce8
 
 ## Documentation
 
-This readme offers an basic introduction to the library. The full documentation for Pact JS and the rest of the framework is available at https://docs.pact.io/.
+This readme offers a basic introduction to the library. The full documentation for Pact JS and the rest of the framework is available at https://docs.pact.io/.
 
 - [Installation](#installation)
 - [Consumer Testing](/docs/consumer.md)


### PR DESCRIPTION
Replaced "an" with "a" in readme file.

- [x] `npm run dist` works locally (this will run tests, lint and build) 
- [ ] Commit messages are ready to go in the changelog (see below for details) **(NA as this is a documentation fix)**
- [x] PR template filled in (see below for details)

Results of `npm run dist`:
![image](https://user-images.githubusercontent.com/11500488/207614114-d5202983-1e25-4a17-95e3-77bfd0969b88.png)

