### PR TITLE
Remove most lint directives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "plugin:@typescript-eslint/recommended",
     "airbnb-base",
     "airbnb-typescript/base",
-    // "plugin:mocha/recommended",
     "prettier"
   ],
   "env": {
@@ -41,6 +40,7 @@
   "overrides": [
     {
       "files": ["**/*.spec.ts"],
+      "extends": ["plugin:mocha/recommended"],
       "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off",
@@ -53,6 +53,7 @@
         "class-methods-use-this": "off",
         "chai-friendly/no-unused-expressions": "error",
         "mocha/no-mocha-arrows": "off",
+        "mocha/no-setup-in-describe": "off",
         "no-new": "off"
       }
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,9 +9,6 @@
     "airbnb-typescript/base",
     "prettier"
   ],
-  "env": {
-    "mocha": true
-  },
   "settings": {
     "import/resolver": {
       "typescript": {
@@ -41,6 +38,9 @@
     {
       "files": ["**/*.spec.ts"],
       "extends": ["plugin:mocha/recommended"],
+      "env": {
+        "mocha": true
+      },
       "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,11 @@
         "@typescript-eslint/no-empty-function": "off",
         "no-empty-function": "off",
         "@typescript-eslint/no-unused-expressions": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          { "varsIgnorePattern": "unused" }
+        ],
+        "no-unused-vars": "off",
         "no-unused-expressions": "off",
         "no-new": "off",
         "class-methods-use-this": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "airbnb-base/legacy",
+    "airbnb-base",
+    "airbnb-typescript/base",
     // "plugin:mocha/recommended",
     "prettier"
   ],
@@ -29,12 +30,13 @@
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
+    "@typescript-eslint/no-empty-function": [
+      "error",
+      { "allow": ["constructors"] }
+    ],
     "import/prefer-default-export": "off",
     "no-underscore-dangle": ["error", { "allow": ["__pactMessageMetadata"] }],
-    "no-shadow": "off",
-    "class-methods-use-this": "off",
-    "no-use-before-define": "off",
-    "no-empty-function": ["error", { "allow": ["constructors"] }]
+    "class-methods-use-this": "off"
   },
   "overrides": [
     {
@@ -42,19 +44,16 @@
       "rules": {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-empty-function": "off",
-        "no-empty-function": "off",
         "@typescript-eslint/no-unused-expressions": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",
           { "varsIgnorePattern": "unused" }
         ],
-        "no-unused-vars": "off",
-        "no-unused-expressions": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
         "no-new": "off",
         "class-methods-use-this": "off",
         "chai-friendly/no-unused-expressions": "error",
-        "mocha/no-mocha-arrows": "off",
-        "@typescript-eslint/ban-ts-comment": "off"
+        "mocha/no-mocha-arrows": "off"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,15 +27,14 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error",
     "import/prefer-default-export": "off",
     "no-underscore-dangle": ["error", { "allow": ["__pactMessageMetadata"] }],
+    "no-shadow": "off",
     "class-methods-use-this": "off",
     "no-use-before-define": "off",
-    "no-empty-function": [
-      "error",
-      { "allow": ["constructors"] }
-    ]
+    "no-empty-function": ["error", { "allow": ["constructors"] }]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,22 +26,23 @@
     "project": "tsconfig.json"
   },
   "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-shadow": "error",
-    "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/no-empty-function": [
       "error",
       { "allow": ["constructors"] }
     ],
+    "class-methods-use-this": "off",
     "import/prefer-default-export": "off",
-    "no-underscore-dangle": ["error", { "allow": ["__pactMessageMetadata"] }],
-    "class-methods-use-this": "off"
+    "no-underscore-dangle": ["error", { "allow": ["__pactMessageMetadata"] }]
   },
   "overrides": [
     {
       "files": ["**/*.spec.ts"],
       "rules": {
+        "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-unused-expressions": "off",
@@ -49,11 +50,10 @@
           "error",
           { "varsIgnorePattern": "unused" }
         ],
-        "@typescript-eslint/ban-ts-comment": "off",
-        "no-new": "off",
         "class-methods-use-this": "off",
         "chai-friendly/no-unused-expressions": "error",
-        "mocha/no-mocha-arrows": "off"
+        "mocha/no-mocha-arrows": "off",
+        "no-new": "off"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
       "rules": {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-empty-function": "off",
+        "no-empty-function": "off",
         "@typescript-eslint/no-unused-expressions": "off",
         "no-unused-expressions": "off",
         "no-new": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "enhanced-resolve": "^3.4.1",
         "eslint": "^8.19.0",
         "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.2.1",
         "eslint-plugin-chai-friendly": "^0.7.2",
@@ -4440,6 +4441,21 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-config-airbnb-base": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.13.0",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -13547,6 +13563,15 @@
         "object.assign": "^4.1.2",
         "object.entries": "^1.1.5",
         "semver": "^6.3.0"
+      }
+    },
+    "eslint-config-airbnb-typescript": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^15.0.0"
       }
     },
     "eslint-config-prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-mocha": "^10.0.5",
-        "eslint-plugin-prettier": "^4.2.1",
         "jasmine-core": "~2.9.1",
         "lodash.clone": "^4.5.0",
         "mocha": "^9.1.1",
@@ -4655,26 +4654,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -5072,11 +5051,6 @@
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -8682,17 +8656,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/process": {
@@ -13707,13 +13670,6 @@
         "rambda": "^7.1.0"
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -13890,10 +13846,6 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
       "dev": true
     },
     "fast-glob": {
@@ -16156,13 +16108,6 @@
     "prettier": {
       "version": "2.7.1",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "eslint-plugin-chai-friendly": "^0.7.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^10.0.5",
-    "eslint-plugin-prettier": "^4.2.1",
     "jasmine-core": "~2.9.1",
     "lodash.clone": "^4.5.0",
     "mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "enhanced-resolve": "^3.4.1",
     "eslint": "^8.19.0",
     "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.2.1",
     "eslint-plugin-chai-friendly": "^0.7.2",

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -32,13 +32,17 @@ function detect_osarch() {
     esac
 }
 
-VERSION=$(curl -s https://api.github.com/repos/pact-foundation/pact-plugins/releases | grep pact-plugin-cli | grep tag_name | head -n1 | egrep -o "[0-9\.]+")
+TAG=$(curl -s https://api.github.com/repos/pact-foundation/pact-plugins/releases | jq '.[0].tag_name')
+VERSION=$(echo "$TAG" | tr -d '[:alpha:]-"')
 detect_osarch
 
 if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then
-    echo "--- 🐿  Installing plugins CLI version ${VERSION}"
+    echo "--- 🐿  Installing plugins CLI version '${VERSION}' (from tag ${TAG})"
     mkdir -p ~/.pact/bin
-    curl -L -o ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-${os}-${arch}${ext}.gz
+    DOWNLOAD_LOCATION=https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${VERSION}/pact-plugin-cli-${os}-${arch}${ext}.gz
+    echo "        Downloading from: ${DOWNLOAD_LOCATION}"
+    curl -L -o ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz "${DOWNLOAD_LOCATION}"
+    echo "        Downloaded $(file ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz)"
     gunzip -N -f ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz
     chmod +x ~/.pact/bin/pact-plugin-cli
 fi

--- a/src/common/net.spec.ts
+++ b/src/common/net.spec.ts
@@ -49,7 +49,9 @@ describe('Net', () => {
         }));
 
       // close the servers used in this test as to not conflict with other tests
-      afterEach((done) => closeFn(done));
+      afterEach((done) => {
+        closeFn(done);
+      });
     });
 
     context('when a single host is unavailable', () => {
@@ -65,7 +67,9 @@ describe('Net', () => {
         }));
 
       // close the servers used in this test as to not conflict with other tests
-      afterEach((done) => closeFn(done));
+      afterEach((done) => {
+        closeFn(done);
+      });
     });
   });
 });

--- a/src/common/net.ts
+++ b/src/common/net.ts
@@ -38,17 +38,16 @@ export const isPortAvailable = (port: number, host: string): Promise<void> =>
     return portCheck(port, host);
   });
 
-export const freePort = (): Promise<number> => {
-  return new Promise((res) => {
+export const freePort = (): Promise<number> =>
+  new Promise((res) => {
     const s = net.createServer();
     s.listen(0, () => {
       const addr = s.address();
       if (addr !== null && typeof addr !== 'string') {
-        const port = addr.port;
+        const {port} = addr;
         s.close(() => res(port));
       } else {
         throw Error('unable to find a free port');
       }
     });
   });
-};

--- a/src/common/net.ts
+++ b/src/common/net.ts
@@ -44,7 +44,7 @@ export const freePort = (): Promise<number> =>
     s.listen(0, () => {
       const addr = s.address();
       if (addr !== null && typeof addr !== 'string') {
-        const {port} = addr;
+        const { port } = addr;
         s.close(() => res(port));
       } else {
         throw Error('unable to find a free port');

--- a/src/common/request.ts
+++ b/src/common/request.ts
@@ -3,7 +3,6 @@ import https from 'https';
 import { pathOr } from 'ramda';
 import logger from './logger';
 
-// eslint-disable-next-line no-shadow
 export enum HTTPMethods {
   GET = 'GET',
   POST = 'POST',

--- a/src/dsl/graphql.spec.ts
+++ b/src/dsl/graphql.spec.ts
@@ -190,8 +190,7 @@ describe('GraphQLInteraction', () => {
 
           expect(isMatcher(json.request.body.query)).to.eq(true);
           const r = new RegExp(json.request.body.query.regex, 'g');
-          // eslint-disable-next-line no-useless-escape
-          const lotsOfWhitespace = `{             Hello(id: \$id) { name    } }`;
+          const lotsOfWhitespace = `{             Hello(id: $id) { name    } }`;
           expect(r.test(lotsOfWhitespace)).to.eq(true);
         });
       });

--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -17,8 +17,7 @@ export interface GraphQLVariables {
 const escapeSpace = (s: string) => s.replace(/\s+/g, '\\s*');
 
 const escapeRegexChars = (s: string) =>
-  // eslint-disable-next-line no-useless-escape
-  s.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+  s.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
 
 const escapeGraphQlQuery = (s: string) => escapeSpace(escapeRegexChars(s));
 

--- a/src/dsl/interaction.spec.ts
+++ b/src/dsl/interaction.spec.ts
@@ -69,7 +69,7 @@ describe('Interaction', () => {
       );
     });
 
-    it('throws error when method is not provided', () => {
+    it('throws error when method is not provided but path is provided', () => {
       expect(interaction.withRequest.bind(interaction, { path: '/' })).to.throw(
         Error,
         'You must provide an HTTP method.'

--- a/src/dsl/interaction.spec.ts
+++ b/src/dsl/interaction.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { HTTPMethods } from '../common/request';

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -71,7 +71,7 @@ const throwIfQueryObjectInvalid = (query: QueryObject) => {
 };
 
 export class Interaction {
-  protected state: InteractionState = {};
+  public state: InteractionState = {};
 
   /**
    * Gives a state the provider should be in for this interaction.

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -195,18 +195,18 @@ export class Interaction {
 export const interactionToInteractionObject = (
   interaction: InteractionStateComplete
 ): InteractionObject => ({
-    state: interaction.providerState,
-    uponReceiving: interaction.description,
-    withRequest: {
-      method: interaction.request?.method,
-      path: interaction.request?.path,
-      query: interaction.request?.query,
-      body: interaction.request?.body,
-      headers: interaction.request?.headers,
-    },
-    willRespondWith: {
-      status: interaction.response?.status,
-      body: interaction.response?.body,
-      headers: interaction.response?.headers,
-    },
-  });
+  state: interaction.providerState,
+  uponReceiving: interaction.description,
+  withRequest: {
+    method: interaction.request?.method,
+    path: interaction.request?.path,
+    query: interaction.request?.query,
+    body: interaction.request?.body,
+    headers: interaction.request?.headers,
+  },
+  willRespondWith: {
+    status: interaction.response?.status,
+    body: interaction.response?.body,
+    headers: interaction.response?.headers,
+  },
+});

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -194,8 +194,7 @@ export class Interaction {
 
 export const interactionToInteractionObject = (
   interaction: InteractionStateComplete
-): InteractionObject => {
-  return {
+): InteractionObject => ({
     state: interaction.providerState,
     uponReceiving: interaction.description,
     withRequest: {
@@ -210,5 +209,4 @@ export const interactionToInteractionObject = (
       body: interaction.response?.body,
       headers: interaction.response?.headers,
     },
-  };
-};
+  });

--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars,no-unused-vars */
 import { expect } from 'chai';
 import {
@@ -198,7 +197,6 @@ describe('Matcher', () => {
       describe('when an invalid value is provided', () => {
         it('throws an Error', () => {
           expect(createTheValue(undefined)).to.throw(Error);
-          // eslint-disable-next-line no-empty-function
           expect(createTheValue(() => {})).to.throw(Error);
         });
       });

--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,no-unused-vars */
 import { expect } from 'chai';
 import {
   boolean,
@@ -61,7 +60,7 @@ describe('Matcher', () => {
           },
         };
 
-        const a: AnyTemplate = like(template);
+        const unused: AnyTemplate = like(template);
       });
     });
     describe('with types', () => {
@@ -76,12 +75,12 @@ describe('Matcher', () => {
           },
         };
 
-        const a: AnyTemplate = like(template);
+        const unused: AnyTemplate = like(template);
       });
     });
 
     it('compiles nested likes', () => {
-      const a: AnyTemplate = like({
+      const unused: AnyTemplate = like({
         someArray: ['one', 'two'],
         someNumber: like(1),
         someString: "it's a string",

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -11,7 +11,6 @@ import MatcherError from '../errors/matcherError';
 
 // Note: The following regexes are Ruby formatted,
 // so attempting to parse as JS without modification is probably not going to work as intended!
-/* tslint:disable:max-line-length */
 export const EMAIL_FORMAT = '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$';
 export const ISO8601_DATE_FORMAT =
   '^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$';
@@ -28,7 +27,6 @@ export const IPV4_FORMAT = '^(\\d{1,3}\\.)+\\d{1,3}$';
 export const IPV6_FORMAT =
   '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$';
 export const HEX_FORMAT = '^[0-9a-fA-F]+$';
-/* tslint:enable */
 
 export interface Matcher<T> {
   value?: T;

--- a/src/dsl/verifier/proxy/messages.ts
+++ b/src/dsl/verifier/proxy/messages.ts
@@ -1,12 +1,12 @@
-import logger from '../../../common/logger';
+import express from 'express';
+import bodyParser from 'body-parser';
+import { encode as encodeBase64 } from 'js-base64';
 import {
   MessageDescriptor,
   MessageFromProviderWithMetadata,
   MessageProvider,
 } from '../../message';
-import express from 'express';
-import bodyParser from 'body-parser';
-import { encode as encodeBase64 } from 'js-base64';
+import logger from '../../../common/logger';
 import { ProxyOptions } from './types';
 
 // Find a provider message handler, and invoke it
@@ -32,58 +32,6 @@ export const findMessageHandler = (
   return Promise.resolve(handler);
 };
 
-// Get the Express app that will run on the HTTP Proxy
-export const setupMessageProxyApplication = (
-  config: ProxyOptions
-): express.Express => {
-  const app = express();
-
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use((_, res, next) => {
-    // TODO: this seems to override the metadata for content-type
-    res.header('Content-Type', 'application/json; charset=utf-8');
-    next();
-  });
-
-  // Proxy server will respond to Verifier process
-  app.all('/*', createProxyMessageHandler(config));
-
-  return app;
-};
-
-// Get the API handler for the verification CLI process to invoke on POST /*
-export const createProxyMessageHandler = (
-  config: ProxyOptions
-): ((req: express.Request, res: express.Response) => void) => {
-  return (req, res) => {
-    const message: MessageDescriptor = req.body;
-
-    // Invoke the handler, and return the JSON response body
-    // wrapped in a Message
-    findMessageHandler(message, config)
-      .then((handler) => handler(message))
-      .then((messageFromHandler) => {
-        if (hasMetadata(messageFromHandler)) {
-          const metadata = encodeBase64(
-            JSON.stringify(messageFromHandler.__pactMessageMetadata)
-          );
-          res.header('Pact-Message-Metadata', metadata);
-          res.header('PACT_MESSAGE_METADATA', metadata);
-
-          return res.json(messageFromHandler.message);
-        }
-        return res.json(messageFromHandler);
-      })
-      .catch((e) => res.status(500).send(e));
-  };
-};
-
-// // Get the Proxy we'll pass to the CLI for verification
-// export const setupProxyServer = (
-//   app: (request: http.IncomingMessage, response: http.ServerResponse) => void
-// ): http.Server => http.createServer(app).listen();
-
 const hasMetadata = (
   o: unknown | MessageFromProviderWithMetadata
 ): o is MessageFromProviderWithMetadata =>
@@ -106,3 +54,55 @@ export const providerWithMetadata =
           }
         : { __pactMessageMetadata: metadata, message }
     );
+
+// Get the API handler for the verification CLI process to invoke on POST /*
+export const createProxyMessageHandler =
+  (
+    config: ProxyOptions
+  ): ((req: express.Request, res: express.Response) => void) =>
+  (req, res) => {
+    const message: MessageDescriptor = req.body;
+
+    // Invoke the handler, and return the JSON response body
+    // wrapped in a Message
+    findMessageHandler(message, config)
+      .then((handler) => handler(message))
+      .then((messageFromHandler) => {
+        if (hasMetadata(messageFromHandler)) {
+          const metadata = encodeBase64(
+            JSON.stringify(messageFromHandler.__pactMessageMetadata)
+          );
+          res.header('Pact-Message-Metadata', metadata);
+          res.header('PACT_MESSAGE_METADATA', metadata);
+
+          return res.json(messageFromHandler.message);
+        }
+        return res.json(messageFromHandler);
+      })
+      .catch((e) => res.status(500).send(e));
+  };
+
+// Get the Express app that will run on the HTTP Proxy
+export const setupMessageProxyApplication = (
+  config: ProxyOptions
+): express.Express => {
+  const app = express();
+
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use((_, res, next) => {
+    // TODO: this seems to override the metadata for content-type
+    res.header('Content-Type', 'application/json; charset=utf-8');
+    next();
+  });
+
+  // Proxy server will respond to Verifier process
+  app.all('/*', createProxyMessageHandler(config));
+
+  return app;
+};
+
+// // Get the Proxy we'll pass to the CLI for verification
+// export const setupProxyServer = (
+//   app: (request: http.IncomingMessage, response: http.ServerResponse) => void
+// ): http.Server => http.createServer(app).listen();

--- a/src/dsl/verifier/proxy/parseBody.ts
+++ b/src/dsl/verifier/proxy/parseBody.ts
@@ -4,7 +4,6 @@ interface ReqBodyExtended extends http.IncomingMessage {
   body?: Buffer | Record<string, unknown>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const parseBody = (
   proxyReq: http.ClientRequest,
   req: ReqBodyExtended

--- a/src/dsl/verifier/proxy/proxy.ts
+++ b/src/dsl/verifier/proxy/proxy.ts
@@ -11,6 +11,11 @@ import { createRequestTracer, createResponseTracer } from './tracer';
 import { parseBody } from './parseBody';
 import { createProxyMessageHandler } from './messages';
 
+// A base URL is always needed for the proxy, even
+// if there are no targets to proxy (e.g. in the case
+// of message pact
+const defaultBaseURL = () => 'http://127.0.0.1/';
+
 // Listens for the server start event
 export const waitForServerReady = (server: http.Server): Promise<http.Server> =>
   new Promise((resolve, reject) => {
@@ -82,11 +87,4 @@ export const createProxy = (
   return http
     .createServer(app)
     .listen(undefined, config.proxyHost || '127.0.0.1');
-};
-
-// A base URL is always needed for the proxy, even
-// if there are no targets to proxy (e.g. in the case
-// of message pact
-const defaultBaseURL = () => {
-  return 'http://127.0.0.1/';
 };

--- a/src/dsl/verifier/proxy/stateHandler/stateHandler.spec.ts
+++ b/src/dsl/verifier/proxy/stateHandler/stateHandler.spec.ts
@@ -18,7 +18,6 @@ describe('#createProxyStateHandler', () => {
     status: (status: number) => {
       res = status;
       return {
-        // eslint-disable-next-line no-empty-function
         send: () => {},
       };
     },

--- a/src/dsl/verifier/proxy/tracer.ts
+++ b/src/dsl/verifier/proxy/tracer.ts
@@ -45,9 +45,6 @@ export const createResponseTracer =
       return oldWrite.apply(res, [chunk]);
     };
 
-    // I think the type definitions in @types/node is wrong/broken.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     res.end = (chunk: Parameters<typeof res.write>[0]) => {
       if (chunk) {
         chunks.push(Buffer.from(chunk));
@@ -58,7 +55,7 @@ export const createResponseTracer =
           removeEmptyResponseProperties(body, res)
         )}`
       );
-      oldEnd.apply(res, [chunk]);
+      return oldEnd.apply(res, [chunk]);
     };
     if (typeof next === 'function') {
       next();

--- a/src/dsl/verifier/verifier.ts
+++ b/src/dsl/verifier/verifier.ts
@@ -2,19 +2,20 @@
  * Provider Verifier service
  * @module ProviderVerifier
  */
-import serviceFactory from '@pact-foundation/pact-core';
-import { VerifierOptions as PactCoreVerifierOptions } from '@pact-foundation/pact-core';
+import serviceFactory, {
+  VerifierOptions as PactCoreVerifierOptions,
+} from '@pact-foundation/pact-core';
 import { omit, isEmpty } from 'lodash';
 import * as http from 'http';
 import * as url from 'url';
 
+import { AddressInfo } from 'net';
 import logger, { setLogLevel } from '../../common/logger';
 
 import ConfigurationError from '../../errors/configurationError';
 import { localAddresses } from '../../common/net';
 import { createProxy, waitForServerReady } from './proxy';
 import { VerifierOptions } from './types';
-import { AddressInfo } from 'net';
 
 export class Verifier {
   private address = 'http://127.0.0.1';
@@ -119,14 +120,14 @@ export class Verifier {
   // Run the Verification CLI process
   private runProviderVerification() {
     return (server: http.Server) => {
-      const port = (server.address() as AddressInfo).port;
+      const { port } = server.address() as AddressInfo;
       const opts: PactCoreVerifierOptions = {
         providerStatesSetupUrl: `${this.address}:${port}${this.stateSetupPath}`,
         ...omit(this.config, 'handlers'),
         providerBaseUrl: `${this.address}:${port}`,
         transports: this.config.transports?.concat([
           {
-            port: port,
+            port,
             path: this.messageTransportPath,
             protocol: 'message',
           },

--- a/src/httpPact/ffi.spec.ts
+++ b/src/httpPact/ffi.spec.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+import { ConsumerInteraction } from '@pact-foundation/pact-core';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -39,7 +39,7 @@ describe('Pact FFI', () => {
 
         const interaction = {
           withQuery: queryMock,
-        };
+        } as unknown as ConsumerInteraction; // TODO replace with proper mock
         const query = {
           foo: ['bar', 'baz'],
         };
@@ -55,7 +55,7 @@ describe('Pact FFI', () => {
 
         const interaction = {
           withQuery: queryMock,
-        };
+        } as unknown as ConsumerInteraction; // TODO replace with proper mock
         const query = {
           foo: 'bar',
         };
@@ -70,7 +70,7 @@ describe('Pact FFI', () => {
 
         const interaction = {
           withQuery: queryMock,
-        };
+        } as unknown as ConsumerInteraction; // TODO replace with proper mock
         const query = {
           foo: 'bar',
           baz: ['bat', 'foo'],

--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -11,7 +11,6 @@ import { forEachObjIndexed } from 'ramda';
 import { isArray } from 'util';
 import { AnyTemplate } from '../v3/matchers';
 
-// eslint-disable-next-line
 enum INTERACTION_PART {
   REQUEST = 1,
   RESPONSE = 2,

--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -1,5 +1,7 @@
 import { ConsumerInteraction } from '@pact-foundation/pact-core/src/consumer/index';
 
+import { forEachObjIndexed } from 'ramda';
+import { isArray } from 'util';
 import {
   RequestOptions,
   ResponseOptions,
@@ -7,11 +9,9 @@ import {
   Query,
 } from '../dsl/interaction';
 import { Matcher, matcherValueOrString } from '../dsl/matchers';
-import { forEachObjIndexed } from 'ramda';
-import { isArray } from 'util';
 import { AnyTemplate } from '../v3/matchers';
 
-enum INTERACTION_PART {
+enum InteractionPart {
   REQUEST = 1,
   RESPONSE = 2,
 }
@@ -31,26 +31,6 @@ export const contentTypeFromHeaders = (
   }, headers || {});
 
   return contentType;
-};
-
-export const setRequestDetails = (
-  interaction: ConsumerInteraction,
-  req: RequestOptions
-): void => {
-  setRequestMethodAndPath(interaction, req);
-  setBody(INTERACTION_PART.REQUEST, interaction, req.headers, req.body);
-  setHeaders(INTERACTION_PART.REQUEST, interaction, req.headers);
-  setQuery(interaction, req.query);
-};
-
-export const setResponseDetails = (
-  interaction: ConsumerInteraction,
-  res: ResponseOptions
-): void => {
-  interaction.withStatus(res.status);
-
-  setBody(INTERACTION_PART.RESPONSE, interaction, res.headers, res.body);
-  setHeaders(INTERACTION_PART.RESPONSE, interaction, res.headers);
 };
 
 export const setRequestMethodAndPath = (
@@ -80,7 +60,7 @@ export const setQuery = (
 };
 
 export const setBody = (
-  part: INTERACTION_PART,
+  part: InteractionPart,
   interaction: ConsumerInteraction,
   headers?: Headers,
   body?: AnyTemplate
@@ -90,10 +70,10 @@ export const setBody = (
     const contentType = contentTypeFromHeaders(headers, CONTENT_TYPE_JSON);
 
     switch (part) {
-      case INTERACTION_PART.REQUEST:
+      case InteractionPart.REQUEST:
         interaction.withRequestBody(matcher, contentType);
         break;
-      case INTERACTION_PART.RESPONSE:
+      case InteractionPart.RESPONSE:
         interaction.withResponseBody(matcher, contentType);
         break;
       default:
@@ -103,17 +83,17 @@ export const setBody = (
 };
 
 export const setHeaders = (
-  part: INTERACTION_PART,
+  part: InteractionPart,
   interaction: ConsumerInteraction,
   headers?: Headers
 ): void => {
   forEachObjIndexed((v, k) => {
     switch (part) {
-      case INTERACTION_PART.REQUEST:
+      case InteractionPart.REQUEST:
         interaction.withRequestHeader(`${k}`, 0, matcherValueOrString(v));
 
         break;
-      case INTERACTION_PART.RESPONSE:
+      case InteractionPart.RESPONSE:
         interaction.withResponseHeader(`${k}`, 0, matcherValueOrString(v));
 
         break;
@@ -122,4 +102,24 @@ export const setHeaders = (
         break;
     }
   }, headers);
+};
+
+export const setRequestDetails = (
+  interaction: ConsumerInteraction,
+  req: RequestOptions
+): void => {
+  setRequestMethodAndPath(interaction, req);
+  setBody(InteractionPart.REQUEST, interaction, req.headers, req.body);
+  setHeaders(InteractionPart.REQUEST, interaction, req.headers);
+  setQuery(interaction, req.query);
+};
+
+export const setResponseDetails = (
+  interaction: ConsumerInteraction,
+  res: ResponseOptions
+): void => {
+  interaction.withStatus(res.status);
+
+  setBody(InteractionPart.RESPONSE, interaction, res.headers, res.body);
+  setHeaders(InteractionPart.RESPONSE, interaction, res.headers);
 };

--- a/src/httpPact/index.spec.ts
+++ b/src/httpPact/index.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -6,6 +5,7 @@ import sinonChai from 'sinon-chai';
 import { PactOptions, PactOptionsComplete } from '../dsl/options';
 import { Pact } from '.';
 import { ConsumerInteraction, ConsumerPact } from '@pact-foundation/pact-core';
+import { MockService } from '../dsl/mockService';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -143,7 +143,7 @@ describe('Pact', () => {
       const createMockServer = sinon.stub().returns(1234);
       const pactMock: ConsumerPact = {
         createMockServer,
-      };
+      } as unknown as ConsumerPact; // TODO replace with proper mock
       const interactionMock: ConsumerInteraction = {
         uponReceiving,
         given,
@@ -154,10 +154,12 @@ describe('Pact', () => {
         withResponseBody,
         withResponseHeader,
         withStatus,
-      };
+      } as unknown as ConsumerInteraction; // TODO replace with proper mock
+      // @ts-ignore TODO refactor the class to remove the need for this
       p.pact = pactMock;
+      // @ts-ignore: TODO refactor the class to remove the need for this
       p.interaction = interactionMock;
-      p.mockService = {};
+      p.mockService = {} as MockService;
 
       p.addInteraction({
         state: 'some state',

--- a/src/httpPact/index.spec.ts
+++ b/src/httpPact/index.spec.ts
@@ -2,9 +2,9 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ConsumerInteraction, ConsumerPact } from '@pact-foundation/pact-core';
 import { PactOptions, PactOptionsComplete } from '../dsl/options';
 import { Pact } from '.';
-import { ConsumerInteraction, ConsumerPact } from '@pact-foundation/pact-core';
 import { MockService } from '../dsl/mockService';
 
 chai.use(sinonChai);

--- a/src/httpPact/index.ts
+++ b/src/httpPact/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-promise-executor-return */
 import serviceFactory from '@pact-foundation/pact-core';
 
 import {

--- a/src/httpPact/tracing.ts
+++ b/src/httpPact/tracing.ts
@@ -4,13 +4,20 @@ import logger from '../common/logger';
 
 export const traceHttpInteractions = (): void => {
   const originalRequest = http.request;
-  // TODO: Need to look into the types here. They seemed to have changed
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   http.request = (
-    options: RequestOptions,
-    cb: (res: IncomingMessage) => void
+    options: RequestOptions | string | URL,
+    cb: RequestOptions | ((res: IncomingMessage) => void) | undefined
   ): ClientRequest => {
+    if (typeof options === 'string' || options instanceof URL) {
+      throw new Error(
+        'invoking traced requests with a string or a URL first argument is not supported'
+      );
+    }
+    if (typeof cb !== 'function') {
+      throw new Error(
+        'invoking traced requests with a non-function second argument is not supported'
+      );
+    }
     const requestBodyChunks: Buffer[] = [];
     const responseBodyChunks: Buffer[] = [];
     const hijackedCallback = (res: IncomingMessage) => {

--- a/src/messageConsumerPact.spec.ts
+++ b/src/messageConsumerPact.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-expression no-empty */
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -27,7 +27,6 @@ import { SpecificationVersion } from './v3';
 
 const DEFAULT_PACT_DIR = './pacts';
 
-// eslint-disable-next-line no-shadow
 enum ContentType {
   JSON,
   BINARY,

--- a/src/messageProviderPact.spec.ts
+++ b/src/messageProviderPact.spec.ts
@@ -159,7 +159,6 @@ describe('MesageProvider', () => {
   describe('#waitForServerReady', () => {
     describe('when the http server starts up', () => {
       it('returns a resolved promise', () => {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function, no-empty-function
         const server = http.createServer(() => {}).listen();
 
         return expect(waitForServerReady(server)).to.eventually.be.fulfilled;

--- a/src/messageProviderPact.spec.ts
+++ b/src/messageProviderPact.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-expression no-empty */
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/src/messageProviderPact.ts
+++ b/src/messageProviderPact.ts
@@ -10,6 +10,7 @@ import * as http from 'http';
 import bodyParser from 'body-parser';
 import { encode as encodeBase64 } from 'js-base64';
 
+import { AddressInfo } from 'net';
 import {
   MessageDescriptor,
   MessageFromProviderWithMetadata,
@@ -17,7 +18,6 @@ import {
 } from './dsl/message';
 import logger, { setLogLevel } from './common/logger';
 import { PactMessageProviderOptions } from './dsl/options';
-import { AddressInfo } from 'net';
 
 // Listens for the server start event
 // Converts event Emitter to a Promise

--- a/src/v3/display.ts
+++ b/src/v3/display.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/first */
 import { join, toPairs, map, flatten } from 'ramda';
 import {
   Mismatch,

--- a/src/v3/display.ts
+++ b/src/v3/display.ts
@@ -9,6 +9,37 @@ import {
   PluginContentMismatch,
 } from '@pact-foundation/pact-core/src/consumer/index';
 
+// TODO: update Matching in the rust core to have a `type` property
+//       to avoid having to do this check!
+
+const isMismatchingResultPlugin = (
+  obj: MatchingResult
+): obj is MatchingResultPlugin => {
+  if (
+    (obj as MatchingResultPlugin).error !== undefined &&
+    (obj as MatchingResultPlugin).mismatches
+  )
+    return true;
+  return false;
+};
+
+const isPluginContentMismatch = (
+  obj: Mismatch
+): obj is PluginContentMismatch => {
+  const cast = obj as PluginContentMismatch;
+
+  if (
+    cast.diff !== undefined ||
+    (cast.expected !== undefined &&
+      cast.actual !== undefined &&
+      cast.mismatch !== undefined &&
+      cast.path !== undefined)
+  )
+    return true;
+
+  return false;
+};
+
 export function displayQuery(query: Record<string, string[]>): string {
   const pairs = toPairs(query);
   const mapped = flatten(
@@ -133,34 +164,3 @@ export function generateMockServerError(
     }),
   ].join('\n');
 }
-
-// TODO: update Matching in the rust core to have a `type` property
-//       to avoid having to do this check!
-
-const isMismatchingResultPlugin = (
-  obj: MatchingResult
-): obj is MatchingResultPlugin => {
-  if (
-    (obj as MatchingResultPlugin).error !== undefined &&
-    (obj as MatchingResultPlugin).mismatches
-  )
-    return true;
-  return false;
-};
-
-const isPluginContentMismatch = (
-  obj: Mismatch
-): obj is PluginContentMismatch => {
-  const cast = obj as PluginContentMismatch;
-
-  if (
-    cast.diff !== undefined ||
-    (cast.expected !== undefined &&
-      cast.actual !== undefined &&
-      cast.mismatch !== undefined &&
-      cast.path !== undefined)
-  )
-    return true;
-
-  return false;
-};

--- a/src/v3/ffi.ts
+++ b/src/v3/ffi.ts
@@ -1,8 +1,7 @@
 import { forEachObjIndexed } from 'ramda';
 import { ConsumerInteraction } from '@pact-foundation/pact-core/src/consumer/index';
 import { TemplateHeaders, V3Request, V3Response } from './types';
-import { matcherValueOrString } from './matchers';
-import { MatchersV3 } from '../v3';
+import * as MatchersV3 from './matchers';
 
 type TemplateHeaderArrayValue = string[] | MatchersV3.Matcher<string>[];
 
@@ -10,24 +9,31 @@ export const setRequestDetails = (
   interaction: ConsumerInteraction,
   req: V3Request
 ): void => {
-  interaction.withRequest(req.method, matcherValueOrString(req.path));
+  interaction.withRequest(
+    req.method,
+    MatchersV3.matcherValueOrString(req.path)
+  );
   forEachObjIndexed((v, k) => {
     if (Array.isArray(v)) {
       (v as TemplateHeaderArrayValue).forEach((header, index) => {
-        interaction.withRequestHeader(k, index, matcherValueOrString(header));
+        interaction.withRequestHeader(
+          k,
+          index,
+          MatchersV3.matcherValueOrString(header)
+        );
       });
     } else {
-      interaction.withRequestHeader(k, 0, matcherValueOrString(v));
+      interaction.withRequestHeader(k, 0, MatchersV3.matcherValueOrString(v));
     }
   }, req.headers);
 
   forEachObjIndexed((v, k) => {
     if (Array.isArray(v)) {
       (v as unknown[]).forEach((vv, i) => {
-        interaction.withQuery(k, i, matcherValueOrString(vv));
+        interaction.withQuery(k, i, MatchersV3.matcherValueOrString(vv));
       });
     } else {
-      interaction.withQuery(k, 0, matcherValueOrString(v));
+      interaction.withQuery(k, 0, MatchersV3.matcherValueOrString(v));
     }
   }, req.query);
 };
@@ -39,7 +45,7 @@ export const setResponseDetails = (
   interaction.withStatus(res.status);
 
   forEachObjIndexed((v, k) => {
-    interaction.withResponseHeader(k, 0, matcherValueOrString(v));
+    interaction.withResponseHeader(k, 0, MatchersV3.matcherValueOrString(v));
   }, res.headers);
 };
 
@@ -51,7 +57,7 @@ export const contentTypeFromHeaders = (
   let contentType: string | MatchersV3.Matcher<string> = defaultContentType;
   forEachObjIndexed((v, k) => {
     if (`${k}`.toLowerCase() === 'content-type') {
-      contentType = matcherValueOrString(v);
+      contentType = MatchersV3.matcherValueOrString(v);
     }
   }, headers || {});
 

--- a/src/v3/ffi.ts
+++ b/src/v3/ffi.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/first */
 import { forEachObjIndexed } from 'ramda';
 import { ConsumerInteraction } from '@pact-foundation/pact-core/src/consumer/index';
 import { TemplateHeaders, V3Request, V3Response } from './types';

--- a/src/v3/pact.ts
+++ b/src/v3/pact.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/first */
 import { forEachObjIndexed, equals } from 'ramda';
 import { makeConsumerPact } from '@pact-foundation/pact-core';
 import {

--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -1,7 +1,6 @@
 import * as MatchersV3 from './matchers';
 import { JsonMap } from '../common/jsonTypes';
 
-// eslint-disable-next-line no-shadow
 export enum SpecificationVersion {
   SPECIFICATION_VERSION_V2 = 3,
   SPECIFICATION_VERSION_V3 = 4,

--- a/src/v3/xml/xmlElement.spec.ts
+++ b/src/v3/xml/xmlElement.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/dot-notation */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 import * as chai from 'chai';
 import { describe } from 'mocha';
 import { XmlText } from './xmlText';
@@ -28,14 +25,15 @@ describe('xml element', () => {
       expect(xml.children[0], 'first child of XML element').to.have.property(
         'content'
       );
-      expect(xml.children[0].content, 'content of first child').to.equal(
-        'some string'
-      );
+      expect(
+        (xml.children[0] as XmlText).content,
+        'content of first child'
+      ).to.equal('some string');
       expect(xml.children[0], 'first child of XML element').to.have.property(
         'matcher'
       );
-      expect(xml.children[0].matcher, 'matcher of the first child').to.be
-        .undefined;
+      expect((xml.children[0] as XmlText).matcher, 'matcher of the first child')
+        .to.be.undefined;
     });
 
     it('can be called with a Matcher', () => {
@@ -73,17 +71,18 @@ describe('xml element', () => {
       expect(xml, 'XML element').to.have.property('children');
       expect(xml.children, 'children of XML element').to.be.lengthOf(7);
       for (let i = 0; i < 7; i += 1) {
-        expect(xml.children[i]).to.be.instanceOf(XmlText);
-        expect(xml.children[i]).to.have.property('content');
-        expect(xml.children[i].content).not.to.be.empty;
-        expect(xml.children[i].content).to.be.a('string');
-        expect(xml.children[i]).to.have.property('matcher');
-        expect(xml.children[i].matcher).to.have.property('value');
-        expect(xml.children[i].matcher.value).to.be.a('string');
-        expect(xml.children[i].matcher.value).not.to.be.empty;
-        expect(xml.children[i].matcher).to.have.property('pact:matcher:type');
-        expect(xml.children[i].matcher['pact:matcher:type']).to.be.a('string');
-        expect(xml.children[i].matcher['pact:matcher:type']).not.to.be.empty;
+        const child: XmlText = xml.children[i] as XmlText;
+        expect(child).to.be.instanceOf(XmlText);
+        expect(child).to.have.property('content');
+        expect(child.content).not.to.be.empty;
+        expect(child.content).to.be.a('string');
+        expect(child).to.have.property('matcher');
+        expect(child.matcher).to.have.property('value');
+        expect(child.matcher?.value).to.be.a('string');
+        expect(child.matcher?.value).not.to.be.empty;
+        expect(child.matcher).to.have.property('pact:matcher:type');
+        expect(child.matcher?.['pact:matcher:type']).to.be.a('string');
+        expect(child.matcher?.['pact:matcher:type']).not.to.be.empty;
       }
     });
     it('sets content to an empty string if the Matcher has no value', () => {
@@ -98,15 +97,16 @@ describe('xml element', () => {
 
       expect(xml, 'XML element').to.have.property('children');
       expect(xml.children, 'children of XML element').to.be.lengthOf(1);
-      expect(xml.children[0]).to.be.instanceOf(XmlText);
-      expect(xml.children[0]).to.have.property('content');
-      expect(xml.children[0].content).to.be.empty;
-      expect(xml.children[0].content).to.be.a('string');
-      expect(xml.children[0]).to.have.property('matcher');
-      expect(xml.children[0].matcher).not.to.have.property('value');
-      expect(xml.children[0].matcher).to.have.property('pact:matcher:type');
-      expect(xml.children[0].matcher['pact:matcher:type']).to.be.a('string');
-      expect(xml.children[0].matcher['pact:matcher:type']).not.to.be.empty;
+      const child: XmlText = xml.children[0] as XmlText;
+      expect(child).to.be.instanceOf(XmlText);
+      expect(child).to.have.property('content');
+      expect(child.content).to.be.empty;
+      expect(child.content).to.be.a('string');
+      expect(child).to.have.property('matcher');
+      expect(child.matcher).not.to.have.property('value');
+      expect(child.matcher).to.have.property('pact:matcher:type');
+      expect(child.matcher?.['pact:matcher:type']).to.be.a('string');
+      expect(child.matcher?.['pact:matcher:type']).not.to.be.empty;
     });
   });
 });

--- a/src/v3/xml/xmlElement.ts
+++ b/src/v3/xml/xmlElement.ts
@@ -13,7 +13,7 @@ const modifyElementWithCallback = (el: XmlElement, cb?: XmlCallback) => {
 export class XmlElement extends XmlNode {
   private attributes: XmlAttributes;
 
-  private children: XmlNode[] = [];
+  children: XmlNode[] = [];
 
   constructor(public name: string) {
     super();

--- a/src/v3/xml/xmlText.ts
+++ b/src/v3/xml/xmlText.ts
@@ -2,7 +2,7 @@ import { Matcher } from '../matchers';
 import { XmlNode } from './xmlNode';
 
 export class XmlText extends XmlNode {
-  constructor(private content: string, private matcher?: Matcher<string>) {
+  constructor(public content: string, public matcher?: Matcher<string>) {
     super();
   }
 }

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -2,10 +2,7 @@ import { AnyJson, JsonMap } from '../../common/jsonTypes';
 import { Metadata } from '../../dsl/message';
 import { AnyTemplate } from '../../v3/matchers';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface MessageContents {
-  // contents: Buffer // TODO
-}
+export type MessageContents = unknown; // TODO { contents: Buffer }
 
 // TODO: this is currently an empty object,
 //       it will eventually be populated with a Buffer


### PR DESCRIPTION
This PR removes almost all lint directives from the source. Each commit is reasonably self-contained, so you could cherry-pick if you don't want some of them.

Key points:

* The typescript type checker was explicitly turned off (!) in a few files. This is not a good idea, as it means that land mines and maintainability issues are left for future developers
* Some private properties are relied on in tests. Since most of these were on the new data classes, I just made the data class properties public.
* Some tests either used incomplete mocks, or wrote to private properties. I left those with TODO comments
* I didn't touch V4 because it looks like it's work in progress.
* The javascript eslint settings are not disabled by the corresponding typescript rules for some reason. This is annoying, as it means there are two settings for the same rule in the rules file. This should be fixed, but it's out of scope for this PR.
* Almost all lint directives were unnecessary