### PR TITLE
build: Improve logging in install-plugins script

### DIFF
--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -6,14 +6,13 @@ set -x
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the script is running
 . "$SCRIPT_DIR"/lib/robust-bash.sh
 
-require_env_var GIT_REF
 
 npm ci
 
 npm run dist
 cp package.json ./dist
 
-export GIT_BRANCH=${GITHUB_HEAD_REF:-${GIT_REF#refs/heads/}}
+export GIT_BRANCH=master
 
 export PACT_BROKER_USERNAME="dXfltyFMgNOFZAxr8io9wJ37iUpY42M"
 export PACT_BROKER_PASSWORD="O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -32,7 +32,20 @@ function detect_osarch() {
     esac
 }
 
-TAG=$(curl -s https://api.github.com/repos/pact-foundation/pact-plugins/releases | jq '.[0].tag_name')
+
+echo "---  🐿 Downloading release metadata from pact-foundation/pact-plugins"
+RELEASE_API_RESPONSE=$(curl -sS https://api.github.com/repos/pact-foundation/pact-plugins/releases)
+TAG=$(echo "$RELEASE_API_RESPONSE" | jq '.[0]?.tag_name')
+if [ -z "${TAG:-}" ]; then
+    echo "--- ❌ FAILED TO GET TAG ❌"
+    echo "    Release API responded with"
+    echo ""
+    echo "$RELEASE_API_RESPONSE"
+
+    echo "   ❌ Release API response was not in expected format"
+fi
+
+
 VERSION=$(echo "$TAG" | tr -d '[:alpha:]-"')
 detect_osarch
 

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -34,7 +34,7 @@ function detect_osarch() {
 }
 
 
-echo "---  🐿 Downloading release metadata from pact-foundation/pact-plugins"
+echo "--- 🐿 Downloading release metadata from pact-foundation/pact-plugins"
 RELEASE_API_RESPONSE=$(curl -sS https://api.github.com/repos/pact-foundation/pact-plugins/releases)
 TAG=$(echo "$RELEASE_API_RESPONSE" | jq '.[0]?.tag_name')
 if [ -z "${TAG:-}" ]; then
@@ -43,7 +43,7 @@ if [ -z "${TAG:-}" ]; then
     echo ""
     echo "$RELEASE_API_RESPONSE"
 
-    echo "   ❌ Release API response was not in expected format"
+    echo "    ❌ Release API response was not in expected format"
     exit 2
 fi
 

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -5,6 +5,7 @@
 # or
 #   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-plugins/master/install-cli.sh -O- | bash
 #
+set -e # Needed for Windows bash, which doesn't read the shebang
 
 function detect_osarch() {
     case $(uname -sm) in

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -44,6 +44,7 @@ if [ -z "${TAG:-}" ]; then
     echo "$RELEASE_API_RESPONSE"
 
     echo "   ❌ Release API response was not in expected format"
+    exit 2
 fi
 
 


### PR DESCRIPTION
This PR:

* Improves the logging for when install-plugins fails
* Ensures that windows actually fails when install-plugins fails

It exposes the problem with install-plugins, which is that it is being rate limited by github. You could fiddle about with a token to fix this, but probably it would be better to do one of:

* Pin the version, avoiding the need for the call (easiest)
* Replace the API call with https://github.com/marketplace/actions/github-api-request
* Remove the need for a plugin cli step entirely by using a package manager (imo, best)