### PR TITLE
docs: Add a note for Alpine + Docker

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,11 @@ This may be resolved by ensuring the `http_proxy`, `https_proxy` and `no_proxy` 
 
 ## Alpine + Docker
 
-Alpine is not currently supported, you should run your Pact tests in a full linux distribution such as Ubunt or Debian.
+Alpine is not currently supported, you should run your Pact tests in a full linux distribution such as Ubuntu or Debian.
+As a workaround to prevent Docker build failure you may install the following packages:
+```sh
+RUN apk add --no-cache libc6-compat python3 make g++
+```
 
 ## Test fails when it should pass
 


### PR DESCRIPTION
The PR adds a workaround on how to install `pact-js` using a base image `node:18-alpine` for example.

It might be helpful when you use Alpine for production build and you want just install the dependencies without actual pact tests execution.