### PR TITLE
chore: Improve types

### DIFF
--- a/src/dsl/matchers.spec.ts
+++ b/src/dsl/matchers.spec.ts
@@ -49,6 +49,28 @@ type ExampleType = {
 describe('Matcher', () => {
   describe('can compile the types', () => {
     describe('with interfaces', () => {
+      it('compiles with nested examples from issue 1054', () => {
+        interface Foo {
+          a: string;
+        }
+
+        const f: Foo = { a: 'working example' };
+
+        like(f);
+        like({ ...f });
+        like(Object.freeze(f));
+
+        interface Room {
+          id: string;
+          foo: Foo;
+        }
+
+        const r: Room = { id: 'some guid', foo: { a: 'example' } };
+
+        like(r);
+        like({ ...r });
+        like(Object.freeze(f));
+      });
       it('compiles when InterfaceToTemplate is used', () => {
         const template: InterfaceToTemplate<ExampleInterface> = {
           someArray: ['one', 'two'],

--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -8,7 +8,7 @@ import {
   Query,
 } from '../dsl/interaction';
 import { Matcher, matcherValueOrString } from '../dsl/matchers';
-import { AnyTemplate } from '../v3/matchers';
+import { AnyTemplate } from '../v3/types';
 import logger from '../common/logger';
 
 enum InteractionPart {

--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -8,7 +8,6 @@ import {
   Query,
 } from '../dsl/interaction';
 import { Matcher, matcherValueOrString } from '../dsl/matchers';
-import { AnyTemplate } from '../v3/types';
 import logger from '../common/logger';
 
 enum InteractionPart {
@@ -63,7 +62,7 @@ export const setBody = (
   part: InteractionPart,
   interaction: ConsumerInteraction,
   headers?: Headers,
-  body?: AnyTemplate
+  body?: unknown
 ): void => {
   if (body) {
     const matcher = matcherValueOrString(body);

--- a/src/v3/ffi.ts
+++ b/src/v3/ffi.ts
@@ -1,9 +1,9 @@
 import { forEachObjIndexed } from 'ramda';
 import { ConsumerInteraction } from '@pact-foundation/pact-core';
-import { TemplateHeaders, V3Request, V3Response } from './types';
+import { Matcher, TemplateHeaders, V3Request, V3Response } from './types';
 import * as MatchersV3 from './matchers';
 
-type TemplateHeaderArrayValue = string[] | MatchersV3.Matcher<string>[];
+type TemplateHeaderArrayValue = string[] | Matcher<string>[];
 
 export const setRequestDetails = (
   interaction: ConsumerInteraction,
@@ -64,7 +64,7 @@ export const contentTypeFromHeaders = (
   headers: TemplateHeaders | undefined,
   defaultContentType: string
 ): string => {
-  let contentType: string | MatchersV3.Matcher<string> = defaultContentType;
+  let contentType: string | Matcher<string> = defaultContentType;
   forEachObjIndexed((v, k) => {
     if (`${k}`.toLowerCase() === 'content-type') {
       contentType = MatchersV3.matcherValueOrString(v);

--- a/src/v3/matchers.spec.ts
+++ b/src/v3/matchers.spec.ts
@@ -4,6 +4,30 @@ import * as MatchersV3 from './matchers';
 const { expect } = chai;
 
 describe('V3 Matchers', () => {
+  it('compiles with nested examples from issue 1054', () => {
+    interface Foo {
+      a: string;
+    }
+
+    const f: Foo = { a: 'working example' };
+
+    MatchersV3.like(f);
+    MatchersV3.like({ ...f });
+    MatchersV3.like(Object.freeze(f));
+
+    interface Room {
+      id: string;
+      foo: Foo;
+    }
+
+    const r: Room = { id: 'some guid', foo: { a: 'example' } };
+
+    MatchersV3.like(r);
+    MatchersV3.like({ ...r });
+    MatchersV3.like(Object.freeze(f));
+    MatchersV3.reify(r);
+  });
+
   describe('#like', () => {
     it('returns a JSON representation of a like matcher', () => {
       const result = MatchersV3.like({

--- a/src/v3/matchers.ts
+++ b/src/v3/matchers.ts
@@ -2,7 +2,6 @@ import { isNil, pickBy, times } from 'ramda';
 import RandExp from 'randexp';
 
 import {
-  AnyTemplate,
   ArrayContainsMatcher,
   DateTimeMatcher,
   Matcher,
@@ -13,6 +12,8 @@ import {
 } from './types';
 
 import { AnyJson, JsonMap } from '../common/jsonTypes';
+
+export * from './types';
 
 export function isMatcher(x: unknown): x is Matcher<unknown> {
   return (
@@ -433,9 +434,7 @@ export function url(
  * Matches the items in an array against a number of variants. Matching is successful if each variant
  * occurs once in the array. Variants may be objects containing matching rules.
  */
-export function arrayContaining(
-  ...variants: AnyTemplate[]
-): ArrayContainsMatcher {
+export function arrayContaining(...variants: unknown[]): ArrayContainsMatcher {
   return {
     'pact:matcher:type': 'arrayContains',
     variants,
@@ -498,11 +497,11 @@ export const matcherValueOrString = (obj: unknown): string => {
  */
 export function reify(input: unknown): AnyJson {
   if (isMatcher(input)) {
-    return reify(input.value as AnyTemplate);
+    return reify(input.value);
   }
 
-  if (Object.prototype.toString.call(input) === '[object Array]') {
-    return (input as Array<AnyTemplate>).map(reify);
+  if (Array.isArray(input)) {
+    return input.map(reify);
   }
 
   if (typeof input === 'object') {
@@ -510,9 +509,9 @@ export function reify(input: unknown): AnyJson {
       return input;
     }
     return Object.keys(input).reduce(
-      (acc: JsonMap, propName: string) => ({
+      (acc: JsonMap, propName: keyof typeof input) => ({
         ...acc,
-        [propName]: reify((input as Record<string, AnyTemplate>)[propName]),
+        [propName]: reify(input[propName]),
       }),
       {}
     );

--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -11,6 +11,11 @@ interface TemplateMap {
 }
 type TemplateArray = Array<AnyTemplate>;
 
+/**
+ * The `AnyTemplate` type is no longer used anywhere in Pact.
+ *
+ * @deprecated This type never really worked, so it has been removed from the Pact API surface. It is still exported to avoid breaking changes with anyone who is importing it. See {@link https://github.com/pact-foundation/pact-js/issues/1054} for details
+ */
 export type AnyTemplate =
   | AnyJson
   | TemplateMap
@@ -55,8 +60,8 @@ export interface DateTimeMatcher extends Matcher<string> {
   format: string;
 }
 
-export interface ArrayContainsMatcher extends Matcher<AnyTemplate[]> {
-  variants: Array<AnyTemplate>;
+export interface ArrayContainsMatcher extends Matcher<unknown[]> {
+  variants: Array<unknown>;
 }
 
 export interface ProviderStateInjectedValue<T> extends Matcher<T> {
@@ -133,14 +138,14 @@ export interface V3Request {
   path: Path;
   query?: TemplateQuery;
   headers?: TemplateHeaders;
-  body?: AnyTemplate;
+  body?: unknown;
   contentType?: string;
 }
 
 export interface V3Response {
   status: number;
   headers?: TemplateHeaders;
-  body?: AnyTemplate;
+  body?: unknown;
   contentType?: string;
 }
 

--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -17,6 +17,12 @@ export type AnyTemplate =
   | TemplateArray
   | Matcher<unknown>;
 
+// TODO: In the next major release, these types should be renamed so they
+// don't clash with the V2 ones. Typescript merges interfaces with the same
+// name, so the calculated type for any Matcher that exists in both V2 and
+// V3 will be wrong. This isn't a major problem as is only likely to affect
+// maintainers, and contributors but it definitely should be corrected.
+
 /**
  * Pact Matcher
  */

--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -1,10 +1,60 @@
-import * as MatchersV3 from './matchers';
-import { JsonMap } from '../common/jsonTypes';
+import { AnyJson, JsonMap } from '../common/jsonTypes';
 
 export enum SpecificationVersion {
   SPECIFICATION_VERSION_V2 = 3,
   SPECIFICATION_VERSION_V3 = 4,
   SPECIFICATION_VERSION_V4 = 5,
+}
+
+interface TemplateMap {
+  [key: string]: AnyJson | AnyTemplate;
+}
+type TemplateArray = Array<AnyTemplate>;
+
+export type AnyTemplate =
+  | AnyJson
+  | TemplateMap
+  | TemplateArray
+  | Matcher<unknown>;
+
+/**
+ * Pact Matcher
+ */
+export interface Matcher<T> {
+  'pact:matcher:type': string;
+  'pact:generator:type'?: string;
+  value?: T | Record<string, T>;
+}
+
+export interface V3RegexMatcher extends Matcher<string> {
+  regex: string;
+  example?: string;
+}
+
+/**
+ * Like Matcher with a minimum number of required values
+ */
+export interface MinLikeMatcher<T> extends Matcher<T> {
+  min: number;
+}
+
+/**
+ * Like Matcher with a maximum number of required values
+ */
+export interface MaxLikeMatcher<T> extends Matcher<T> {
+  max: number;
+}
+
+export interface DateTimeMatcher extends Matcher<string> {
+  format: string;
+}
+
+export interface ArrayContainsMatcher extends Matcher<AnyTemplate[]> {
+  variants: Array<AnyTemplate>;
+}
+
+export interface ProviderStateInjectedValue<T> extends Matcher<T> {
+  expression: string;
 }
 
 /**
@@ -55,17 +105,12 @@ export interface V3ProviderState {
 }
 
 export declare type TemplateHeaders = {
-  [header: string]:
-    | string
-    | MatchersV3.Matcher<string>
-    | (MatchersV3.Matcher<string> | string)[];
+  [header: string]: string | Matcher<string> | (Matcher<string> | string)[];
 };
 
 export type TemplateQuery = Record<
   string,
-  | string
-  | MatchersV3.Matcher<string>
-  | Array<string | MatchersV3.Matcher<string>>
+  string | Matcher<string> | Array<string | Matcher<string>>
 >;
 
 export interface V3Interaction {
@@ -75,20 +120,21 @@ export interface V3Interaction {
   willRespondWith: V3Response;
 }
 
-export type Path = string | MatchersV3.Matcher<string>;
+export type Path = string | Matcher<string>;
+
 export interface V3Request {
   method: string;
   path: Path;
   query?: TemplateQuery;
   headers?: TemplateHeaders;
-  body?: MatchersV3.AnyTemplate;
+  body?: AnyTemplate;
   contentType?: string;
 }
 
 export interface V3Response {
   status: number;
   headers?: TemplateHeaders;
-  body?: MatchersV3.AnyTemplate;
+  body?: AnyTemplate;
   contentType?: string;
 }
 

--- a/src/v3/xml/xmlElement.spec.ts
+++ b/src/v3/xml/xmlElement.spec.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { XmlText } from './xmlText';
 import { XmlElement } from './xmlElement';
 import * as MatchersV3 from '../matchers';
-import { Matcher } from '../matchers';
+import { Matcher } from '../types';
 
 const { expect } = chai;
 

--- a/src/v3/xml/xmlElement.ts
+++ b/src/v3/xml/xmlElement.ts
@@ -1,4 +1,5 @@
-import { Matcher } from '../matchers';
+import { isMatcher } from '../matchers';
+import { Matcher } from '../types';
 import { XmlNode } from './xmlNode';
 import { XmlText } from './xmlText';
 
@@ -59,8 +60,13 @@ export class XmlElement extends XmlNode {
     if (typeof content === 'object' && content['pact:matcher:type']) {
       this.children.push(
         new XmlText(
-          (content as Matcher<string>).value || '',
-          content as Matcher<string>
+          isMatcher(content) &&
+          'value' in content &&
+          content.value !== undefined &&
+          typeof content.value === 'string'
+            ? content.value
+            : '',
+          content
         )
       );
     } else {

--- a/src/v3/xml/xmlText.ts
+++ b/src/v3/xml/xmlText.ts
@@ -1,4 +1,4 @@
-import { Matcher } from '../matchers';
+import { Matcher } from '../types';
 import { XmlNode } from './xmlNode';
 
 export class XmlText extends XmlNode {


### PR DESCRIPTION
- [ ] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

### PR Template

This fixes #1054 by widening the type so that the V3 matchers no longer need to be called with something that can be assigned to `AnyTemplate`. Since this is a widening of the type, it is not a breaking change.

I also removed all references to `AnyTemplate` and added tsdoc so that it is deprecated. It's still exported, but just not used anywhere. It can be removed in a future major release.

While I was there, I refactored the types out of matchers.ts into `types.ts`  for readability. These are now re-exported by `matchers.ts` so that any (inappropriate) deep links will still work, and anyone importing the type from `MatchersV3.Matcher` will still work.

I also added a TODO comment that in some future release we'll need to rename the `interfaces` that have the same names in the V2 and V3 matchers. This affects maintainers, as the current situation will result in confusing types, but I don't think it affects users.

Please don't squash merge this, as the commit messages contain the details for the release notes.