### PR TITLE
chore: Rename message's `StateHandlers` to `MessageStateHandlers`

### DIFF
--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -85,7 +85,7 @@ export interface MessageProviders {
   [name: string]: MessageProvider;
 }
 
-export interface StateHandlers {
+export interface MessageStateHandlers {
   [name: string]: (
     state: string,
     params?: { [name: string]: string }

--- a/src/dsl/options.ts
+++ b/src/dsl/options.ts
@@ -4,7 +4,7 @@
  */
 import { VerifierOptions as PactCoreVerifierOptions } from '@pact-foundation/pact-core';
 import { PactfileWriteMode } from './mockService';
-import { MessageProviders, StateHandlers } from './message';
+import { MessageProviders, MessageStateHandlers } from './message';
 
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
@@ -69,7 +69,7 @@ export interface MessageProviderOptions {
   messageProviders: MessageProviders;
 
   // Prepare any provider states
-  stateHandlers?: StateHandlers;
+  stateHandlers?: MessageStateHandlers;
 }
 
 type ExcludedPactNodeVerifierKeys = Exclude<


### PR DESCRIPTION
In #882 the `StateHandlers` type was changed so that it was incompatible with the other `StateHandlers` type, resulting in conflicts when Typescript merged the two. This caused problems where it was impossible to correctly type `StateHandlers` (see  #1057). 

This PR is a breaking change that simply renames the message `StateHandlers` interface to `MessageStateHandlers`, and therefore fixes #1057.

Probably the better fix would be to introduce a breaking change that makes both types the same again - but I didn't want to get in to untangling what is supposed to happen.

This must not be squash merged, otherwise you won't get the breaking change in the changelog.

- [ ] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)
