### PR TITLE
chore: Rename `uuid` matcher JSDocs param

### DIFF
--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -167,7 +167,7 @@ export function email(address?: string): Matcher<string> {
 
 /**
  * UUID v4 matcher.
- * @param {string} uuuid - a UUID to use as an example.
+ * @param {string} id - a UUID to use as an example.
  */
 export function uuid(id?: string): Matcher<string> {
   return term({


### PR DESCRIPTION
The current implementation of the `uuid` matcher function has a param name that does not match the JSDoc param. Although this doesn't cause any bugs, it may be good to update this for consistency.

<img width="472" alt="Screenshot 2023-03-08 at 09 55 07" src="https://user-images.githubusercontent.com/76700693/223681668-163cc31f-eb4e-4f10-b0a0-da2c7d91d38a.png">

This PR renames the JSDoc param from `uuuid` to `id` to reflect the name of the param
