### PR TITLE
docs: fix Message link in messages examples README

### DIFF
--- a/examples/messages/README.md
+++ b/examples/messages/README.md
@@ -84,7 +84,7 @@ The following test creates a contract for a Dog API handler:
 1. Creates the MessageConsumer class
 1. Setup the expectations for the consumer - here we expect a `dog` object with three fields
 1. Pact will send the message to your message handler. If the handler returns a successful promise, the message is saved, otherwise the test fails. There are a few key things to consider:
-   - The actual request body that Pact will send, will be contained within a [Message](/Users/mfellows/development/public/pact-js/src/dsl/message.ts) object along with other context, so the body must be retrieved via `content` attribute.
+   - The actual request body that Pact will send, will be contained within a [Message](../../src/dsl/message.ts) object along with other context, so the body must be retrieved via `content` attribute.
    - All handlers to be tested must be of the shape `(m: Message) => Promise<any>` - that is, they must accept a `Message` and return a `Promise`. This is how we get around all of the various protocols, and will often require a lightweight adapter function to convert it.
    - In this case, we wrap the actual dogApiHandler with a convenience function `synchronousBodyHandler` provided by Pact, which Promisifies the handler and extracts the contents.
 


### PR DESCRIPTION
Fixed the link to the `Message` object in the messages examples README was incorrect.

Please note: to test this PR, I ran the following commands:

```sh
npm install
```

```sh
npm run dist
```

This resulted in an error:
![Screenshot 2023-06-29 at 09 23 55](https://github.com/pact-foundation/pact-js/assets/44342/f01f1d6b-c5c7-41ac-b1fc-87da0208f3e5)

So I ran this command:

```sh
ENABLE_FEATURE_V4=true npm run dist
```

And that command succeeded.