### PR TITLE
fix: do not split headers by comma

### DIFF
--- a/examples/mocha/test/get-dogs.spec.js
+++ b/examples/mocha/test/get-dogs.spec.js
@@ -47,23 +47,19 @@ describe('The Dog API', () => {
           method: 'GET',
           path: '/dogs',
           headers: {
-            Accept:
-              'application/problem+json, application/json, text/plain, */*',
-            // Accept: [
-            //   'application/problem+json',
-            //   'application/json',
-            //   'text/plain',
-            //   '*/*',
-            // ],
+            // Accept: 'application/problem+json, application/json, text/plain, */*', // <- fails, must use array syntax ❌
+            Accept: [
+              'application/problem+json',
+              'application/json',
+              'text/plain',
+              '*/*',
+            ],
           },
         },
         willRespondWith: {
           status: 200,
           headers: {
-            'Content-Type': Matchers.term({
-              generate: 'application/json',
-              matcher: 'application/json.*',
-            }),
+            'Content-Type': 'application/json',
           },
           body: EXPECTED_BODY,
         },

--- a/src/httpPact/ffi.ts
+++ b/src/httpPact/ffi.ts
@@ -93,9 +93,6 @@ export const setHeaders = (
 
     if (Array.isArray(v)) {
       values = v;
-    } else if (typeof v === 'string') {
-      // Allow comma separated items, such as: "application/problem+json, application/json, */*"
-      values = v.split(',').map((h) => h.trim());
     } else {
       values = [v];
     }
@@ -104,7 +101,7 @@ export const setHeaders = (
       case InteractionPart.REQUEST:
         values.forEach((h, i) => {
           logger.debug(
-            `setting header request value for ${h} at index ${i} to ${JSON.stringify(
+            `setting header request value for ${k} at index ${i} to ${JSON.stringify(
               matcherValueOrString(h)
             )}`
           );


### PR DESCRIPTION
This PR reverts the change added in #1031. Multi-valued headers are supported partially, as they must be specified using the array syntax. The open issues have connected and reproduced upstream issues now, but I think we should release this sooner rather than later.

