### PR TITLE
fix: MessageConsumerPact merge pact file correctly

### DIFF
--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -194,7 +194,7 @@ export class MessageConsumerPact {
       .then(() => {
         this.pact.writePactFile(
           this.config.dir ?? DEFAULT_PACT_DIR,
-          this.config.pactfileWriteMode === 'overwrite'
+          this.config.pactfileWriteMode !== 'overwrite'
         );
       })
       .finally(() => {


### PR DESCRIPTION
### PR Template

This PR fixes the merge parameter for the call to writePactFile() in MessageConsumerPact. The change matches the code for the same call from the Http Pact.
