### PR TITLE
fix: `stateHandlers` type in `VerifierOptions`

### DIFF
--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -85,9 +85,9 @@ export interface MessageProviders {
   [name: string]: MessageProvider;
 }
 
-export interface MessageStateHandlers {
+export interface MessageStateHandlers<T> {
   [name: string]: (
     state: string,
     params?: { [name: string]: string }
-  ) => Promise<unknown>;
+  ) => Promise<T>;
 }

--- a/src/dsl/options.ts
+++ b/src/dsl/options.ts
@@ -69,7 +69,7 @@ export interface MessageProviderOptions {
   messageProviders: MessageProviders;
 
   // Prepare any provider states
-  stateHandlers?: MessageStateHandlers;
+  stateHandlers?: MessageStateHandlers<unknown>;
 }
 
 type ExcludedPactNodeVerifierKeys = Exclude<


### PR DESCRIPTION
- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

### Summary

This PR fixes the `stateHandlers` property on `VerifierOptions` by making the `stateHandlers` on `MessageStateHandlers` a generic type, which is set as `unknown` in the `MessageProviderOptions` type.

This issue is described in #1057, and marked as fixed in #1062, but the type issue still persists in v`12.1.0`

When using the following:
```
stateHandlers: {
  'some state': {
    setup: async () => {},
    teardown: async () => {},
  }
}
```
The following TS error is present
```
Type '{ setup: () => Promise<void>; teardown: () => Promise<void>; }' provides no match for the signature '(state: string, params?: { [name: string]: string; } | undefined): Promise<unknown>'.ts
```
![image](https://github.com/pact-foundation/pact-js/assets/25365573/78daa39d-2954-40e8-9425-f6c0ded51545)

I'm not very familiar with pact yet, this *might* be a breaking change as the `MessageStateHandlers` is exposed.

Would love to know if there's a better way to do this!
