### PR TITLE
Fix/issue 1133 remove `AnyTemplate`

### DIFF
--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -12,8 +12,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the 
 
 echo "Running e2e examples build for node version $(node --version)"
 for i in examples/*; do
-  [ -d "$i" ] || break # prevent failure if not a directory
-  [ -e "$i" ] || break # prevent failure if there are no examples
+  [ -d "$i" ] || continue # prevent failure if not a directory
+  [ -e "$i" ] || continue # prevent failure if there are no examples
   echo "--> running tests for: $i"
   pushd "$i"
   # replace pact dependency with locally build version
@@ -42,8 +42,8 @@ echo "Running Vx examples build"
 # trap "docker kill $BROKER_ID" EXIT
 
 for i in examples/v*/*; do
-  [ -d "$i" ] || break # prevent failure if not a directory
-  [ -e "$i" ] || break # prevent failure if there are no examples
+  [ -d "$i" ] || continue # prevent failure if not a directory
+  [ -e "$i" ] || continue # prevent failure if there are no examples
   echo "------------------------------------------------"
   echo "------------> continuing to test V3/v$ example project: $i"
   node --version

--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -1,5 +1,5 @@
 import { AnyJson } from '../common/jsonTypes';
-import { Matcher, AnyTemplate } from './matchers';
+import { Matcher } from './matchers';
 
 /**
  * Metadata is a map containing message context,
@@ -30,7 +30,7 @@ export interface Message {
   providerStates?: ProviderState[];
   description?: string;
   metadata?: Metadata;
-  contents: AnyTemplate | Buffer;
+  contents: unknown | Buffer;
 }
 
 export interface ConcreteMessage {

--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -10,7 +10,6 @@ import serviceFactory, {
 } from '@pact-foundation/pact-core';
 import { forEachObjIndexed } from 'ramda';
 import { AnyJson } from './common/jsonTypes';
-import { AnyTemplate } from './dsl/matchers';
 import {
   Metadata,
   Message,
@@ -109,7 +108,7 @@ export class MessageConsumerPact {
    * @param {string} content - A description of the Message to be received
    * @returns {Message} MessageConsumer
    */
-  public withContent(content: AnyTemplate): MessageConsumerPact {
+  public withContent(content: unknown): MessageConsumerPact {
     if (isEmpty(content)) {
       throw new ConfigurationError(
         'You must provide a valid JSON document or primitive for the Message.'

--- a/src/v4/message/index.ts
+++ b/src/v4/message/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import { Metadata } from '../../dsl/message';
-import { AnyTemplate } from '../../v3/matchers';
 import { AnyJson, JsonMap } from '../../common/jsonTypes';
 import {
   PluginConfig,
@@ -129,9 +128,7 @@ export class SynchronousMessageWithRequestBuilder
     return this;
   }
 
-  withJSONContent(
-    content: AnyTemplate
-  ): V4SynchronousMessageWithRequestBuilder {
+  withJSONContent(content: unknown): V4SynchronousMessageWithRequestBuilder {
     if (isEmpty(content)) {
       throw new ConfigurationError(
         'You must provide a valid JSON document or primitive for the Message.'
@@ -211,9 +208,7 @@ export class SynchronousMessageWithResponseBuilder
     return this;
   }
 
-  withJSONContent(
-    content: AnyTemplate
-  ): V4SynchronousMessageWithResponseBuilder {
+  withJSONContent(content: unknown): V4SynchronousMessageWithResponseBuilder {
     if (isEmpty(content)) {
       throw new ConfigurationError(
         'You must provide a valid JSON document or primitive for the Message.'

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -1,6 +1,5 @@
 import { AnyJson, JsonMap } from '../../common/jsonTypes';
 import { Metadata } from '../../dsl/message';
-import { AnyTemplate } from '../../v3/matchers';
 
 export type MessageContents = unknown; // TODO { contents: Buffer }
 
@@ -61,7 +60,7 @@ export interface V4SynchronousMessageWithRequestBuilder {
     contentType: string,
     body: Buffer
   ): V4SynchronousMessageWithRequestBuilder;
-  withJSONContent(content: AnyTemplate): V4SynchronousMessageWithRequestBuilder;
+  withJSONContent(content: unknown): V4SynchronousMessageWithRequestBuilder;
 }
 
 export interface V4SynchronousMessageWithRequest {
@@ -76,9 +75,7 @@ export interface V4SynchronousMessageWithResponseBuilder {
     contentType: string,
     body: Buffer
   ): V4SynchronousMessageWithResponseBuilder;
-  withJSONContent(
-    content: AnyTemplate
-  ): V4SynchronousMessageWithResponseBuilder;
+  withJSONContent(content: unknown): V4SynchronousMessageWithResponseBuilder;
 }
 
 export interface V4SynchronousMessageWithPluginContents {

--- a/src/v4/types.ts
+++ b/src/v4/types.ts
@@ -3,7 +3,6 @@ import { V4UnconfiguredSynchronousMessage } from './message/types';
 
 export interface V4ConsumerPact {
   addInteraction(): V4UnconfiguredInteraction;
-  addAsynchronousInteraction(): V4UnconfiguredAsynchronousMessage;
   addSynchronousInteraction(
     description: string
   ): V4UnconfiguredSynchronousMessage;


### PR DESCRIPTION
This change removes the remaining `AnyTemplate` references from previous parts of the code base, excluding the original HTTP DSL (as this is old and stable, and most users would be using `PactV3` or greater).

It is a widening of the types, so is technically backwards compatible on method inputs, however some exported types may be used outside of Pact and the widening from `AnyTemplate` to `unknown` might require type casting (as `unknown` is not iterable, for instance). This is preferable to the current situation however, which is breaking the message pact interface (#1133) and also - as described in #1061 - misleading.