### PR TITLE
fix: revert test workaround / update to matt plugin 0.1.0

### DIFF
--- a/examples/v4/plugins/provider.ts
+++ b/examples/v4/plugins/provider.ts
@@ -17,13 +17,8 @@ export const startTCPServer = (
     sock.on('data', (data) => {
       const msg = parseMattMessage(data.toString());
 
-      // if (msg === 'hellotcp') {
-      //   sock.write(generateMattMessage('tcpworld'));
-      // Workaround for https://github.com/pact-foundation/pact-reference/issues/366
-      const v12_decoded_msg = parseMattMessage(atob(msg));
-      console.log('v12_decoded_msg', v12_decoded_msg);
-      if (v12_decoded_msg === 'hellotcp') {
-        sock.write(btoa(generateMattMessage('tcpworld')));
+      if (msg === 'hellotcp') {
+        sock.write(generateMattMessage('tcpworld'));
       } else {
         sock.write(generateMattMessage('message not understood'));
       }

--- a/examples/v4/plugins/test/matt.consumer.spec.ts
+++ b/examples/v4/plugins/test/matt.consumer.spec.ts
@@ -32,7 +32,7 @@ const { expect } = chai;
           .uponReceiving('an HTTP request to /matt')
           .usingPlugin({
             plugin: 'matt',
-            version: '0.0.9',
+            version: '0.1.0',
           })
           .withRequest('POST', '/matt', (builder) => {
             builder.pluginContents('application/matt', mattRequest);
@@ -75,7 +75,7 @@ const { expect } = chai;
             .addSynchronousInteraction('a MATT message')
             .usingPlugin({
               plugin: 'matt',
-              version: '0.0.9',
+              version: '0.1.0',
             })
             .withPluginContents(mattMessage, 'application/matt')
             .startTransport('matt', HOST)

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -52,7 +52,7 @@ if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then
     chmod +x ~/.pact/bin/pact-plugin-cli
 fi
 
-if [ ! -d ~/.pact/plugins/matt-0.0.9 ]; then
+if [ ! -d ~/.pact/plugins/matt-0.1.0 ]; then
     echo "--- 🐿  Installing MATT plugin"
-  ~/.pact/bin/pact-plugin-cli install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
+  ~/.pact/bin/pact-plugin-cli install https://github.com/you54f/pact-matt-plugin/releases/tag/v0.1.0
 fi

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -83,7 +83,7 @@ describe('V4 Pact', () => {
             .uponReceiving('an HTTP request to /matt')
             .usingPlugin({
               plugin: 'matt',
-              version: '0.0.9',
+              version: '0.1.0',
             })
             .withRequest('POST', '/matt', (builder) => {
               builder.pluginContents('application/matt', mattRequest);
@@ -144,7 +144,7 @@ describe('V4 Pact', () => {
               .addSynchronousInteraction('a MATT message')
               .usingPlugin({
                 plugin: 'matt',
-                version: '0.0.9',
+                version: '0.1.0',
               })
               .withPluginContents(mattMessage, 'application/matt')
               .startTransport('matt', HOST)


### PR DESCRIPTION
Fix for https://github.com/pact-foundation/pact-reference/issues/366

Plugin PR's raised here

- https://github.com/mefellows/pact-matt-plugin/pull/1
- https://github.com/mefellows/pact-matt-plugin/pull/2

Once above are merged, will want the plugin download location reverting back to the source [mefellows](https://github.com/mefellows/pact-matt-plugin) repo over my fork