### PR TITLE
fix: retire lodash omitby to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "lodash.isnil": "4.0.0",
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
-        "lodash.omitby": "4.6.0",
         "pkginfo": "^0.4.1",
         "ramda": "^0.28.0",
         "randexp": "^0.5.3"
@@ -7420,11 +7419,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "node_modules/lodash.omitby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -16943,11 +16937,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "lodash.omitby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "lodash.isnil": "4.0.0",
     "lodash.isundefined": "3.0.1",
     "lodash.omit": "^4.5.0",
-    "lodash.omitby": "4.6.0",
     "pkginfo": "^0.4.1",
     "ramda": "^0.28.0",
     "randexp": "^0.5.3"

--- a/src/dsl/graphql.ts
+++ b/src/dsl/graphql.ts
@@ -3,7 +3,8 @@
  *
  * @module GraphQL
  */
-import { isNil, extend, omitBy, isUndefined } from 'lodash';
+import { isNil, extend, isUndefined } from 'lodash';
+import { reject } from 'ramda';
 import gql from 'graphql-tag';
 import { Interaction, InteractionStateComplete } from './interaction';
 import { regex } from './matchers';
@@ -106,17 +107,14 @@ export class GraphQLInteraction extends Interaction {
 
     this.state.request = extend(
       {
-        body: omitBy(
-          {
-            operationName: this.operation,
-            query: regex({
-              generate: this.query,
-              matcher: escapeGraphQlQuery(this.query),
-            }),
-            variables: this.variables,
-          },
-          isUndefined
-        ),
+        body: reject(isUndefined, {
+          operationName: this.operation,
+          query: regex({
+            generate: this.query,
+            matcher: escapeGraphQlQuery(this.query),
+          }),
+          variables: this.variables,
+        }),
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       },

--- a/src/dsl/interaction.ts
+++ b/src/dsl/interaction.ts
@@ -3,7 +3,8 @@
  * @module Interaction
  */
 
-import { isNil, keys, omitBy } from 'lodash';
+import { isNil, keys } from 'lodash';
+import { reject } from 'ramda';
 import { HTTPMethods, HTTPMethod } from '../common/request';
 import { Matcher, isMatcher, AnyTemplate } from './matchers';
 import ConfigurationError from '../errors/configurationError';
@@ -131,7 +132,7 @@ export class Interaction {
       throwIfQueryObjectInvalid(requestOpts.query);
     }
 
-    this.state.request = omitBy(requestOpts, isNil) as RequestOptions;
+    this.state.request = reject(isNil, requestOpts) as RequestOptions;
 
     return this;
   }
@@ -152,14 +153,11 @@ export class Interaction {
       throw new ConfigurationError('You must provide a status code.');
     }
 
-    this.state.response = omitBy(
-      {
-        body: responseOpts.body,
-        headers: responseOpts.headers || undefined,
-        status: responseOpts.status,
-      },
-      isNil
-    ) as ResponseOptions;
+    this.state.response = reject(isNil, {
+      body: responseOpts.body,
+      headers: responseOpts.headers || undefined,
+      status: responseOpts.status,
+    }) as ResponseOptions;
     return this;
   }
 


### PR DESCRIPTION
# Checklist

- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

# Summary

Mentioned in issue #1169, `lodash.omitby` will be reported security risk by BlackDuck. This PR retired `lodash.omitby` dependency and replaced it with `ramda` to avoid vulnerability.

`lodash.omitby` is used to filter out null and undefined value from a object. `ramda` does not provide same name `omitBy` function but this functionality could be achieved by `ramda.reject` referring to [link](https://github.com/ramda/ramda/issues/2084).
