### PR TITLE
feat: remove feature flag for v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,6 @@ on:
 env:
   GIT_COMMIT: ${{ github.sha }}
   GIT_REF: ${{ github.ref }}
-  ENABLE_FEATURE_V4: true
   LOG_LEVEL: info
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ on:
 env:
   GIT_COMMIT: ${{ github.sha }}
   GIT_REF: ${{ github.ref }}
-  ENABLE_FEATURE_V4: true
   LOG_LEVEL: info
 
 jobs:

--- a/src/v4/index.ts
+++ b/src/v4/index.ts
@@ -11,12 +11,6 @@ export class PactV4 implements V4ConsumerPact {
   private pact: ConsumerPact;
 
   constructor(private opts: PactV4Options) {
-    if (!process.env.ENABLE_FEATURE_V4) {
-      throw Error(
-        "The v4 package is currently in beta and requires the 'ENABLE_FEATURE_V4' environment variable to be set"
-      );
-    }
-
     this.setup();
     this.pact.addMetadata('pact-js', 'version', pactPackageVersion);
   }


### PR DESCRIPTION
V4 interface has been experimental for long enough that it is now a de-facto API. Removing the feature flag.

Documentation updates to follow.