### PR TITLE
chore: allow v3 matchers in message metadata

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ on:
 env:
   GIT_COMMIT: ${{ github.sha }}
   GIT_REF: ${{ github.ref }}
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   LOG_LEVEL: info
 
 jobs:

--- a/examples/messages/consumer/message-consumer.spec.ts
+++ b/examples/messages/consumer/message-consumer.spec.ts
@@ -35,7 +35,7 @@ describe('Message consumer tests', () => {
           }),
         })
         .withMetadata({
-          queue: 'animals',
+          queue: like('animals'),
         })
         .verify(synchronousBodyHandler(dogApiHandler));
     });
@@ -53,7 +53,7 @@ describe('Message consumer tests', () => {
           }),
         })
         .withMetadata({
-          queue: 'animals',
+          queue: like('animals'),
         })
         .verify(synchronousBodyHandler(dogApiHandler));
     });

--- a/examples/messages/package-lock.json
+++ b/examples/messages/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.1.2",
+      "version": "12.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -41,7 +41,6 @@
         "lodash.isnil": "4.0.0",
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
-        "lodash.omitby": "4.6.0",
         "pkginfo": "^0.4.1",
         "ramda": "^0.28.0",
         "randexp": "^0.5.3"
@@ -1649,7 +1648,6 @@
         "lodash.isnil": "4.0.0",
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
-        "lodash.omitby": "4.6.0",
         "mocha": "^9.1.1",
         "mocha-lcov-reporter": "^1.3.0",
         "mockery": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.2.0",
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^14.1.1",
+        "@pact-foundation/pact-core": "^14.3.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-14.1.1.tgz",
-      "integrity": "sha512-hblC2FrwOOX3lfTcYPXFlNfbX+yyafOeeBI2TR7BcaCn1DRAj40OGvw1UAS7f8uf21IHZlA7H39Gs18ik6FY8A==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-14.3.0.tgz",
+      "integrity": "sha512-OwBUA0rBuwHx8sbQ5olY+mzxd03HUpqza/6zGmyQutSb/bc79OAmve7EDYVSfPDYPKOCiGomj61gGAJF8kt1kQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -12878,9 +12878,9 @@
       }
     },
     "@pact-foundation/pact-core": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-14.1.1.tgz",
-      "integrity": "sha512-hblC2FrwOOX3lfTcYPXFlNfbX+yyafOeeBI2TR7BcaCn1DRAj40OGvw1UAS7f8uf21IHZlA7H39Gs18ik6FY8A==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-14.3.0.tgz",
+      "integrity": "sha512-OwBUA0rBuwHx8sbQ5olY+mzxd03HUpqza/6zGmyQutSb/bc79OAmve7EDYVSfPDYPKOCiGomj61gGAJF8kt1kQ==",
       "requires": {
         "chalk": "4.1.2",
         "check-types": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-core": "^14.1.1",
+    "@pact-foundation/pact-core": "^14.3.0",
     "@types/express": "^4.17.11",
     "axios": "^1.6.1",
     "body-parser": "^1.20.0",

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -11,7 +11,7 @@ npm ci --ignore-scripts
 npm run dist
 cp package.json ./dist
 
-export GIT_BRANCH=master
+export GIT_BRANCH=${GITHUB_HEAD_REF:-${GIT_REF#refs/heads/}}
 
 export PACT_BROKER_USERNAME="dXfltyFMgNOFZAxr8io9wJ37iUpY42M"
 export PACT_BROKER_PASSWORD="O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -40,7 +40,7 @@ export interface ArrayMatcher<T> extends Matcher<T> {
   max?: number;
 }
 
-export function isMatcher(x: AnyTemplate): x is Matcher<AnyTemplate> {
+export function isMatcher(x: unknown): x is Matcher<AnyTemplate> {
   return x != null && (x as Matcher<AnyTemplate>).getValue !== undefined;
 }
 

--- a/src/dsl/message.ts
+++ b/src/dsl/message.ts
@@ -1,5 +1,6 @@
 import { AnyJson } from '../common/jsonTypes';
 import { Matcher } from './matchers';
+import { Matcher as MatcherV3 } from '../v3/matchers';
 
 /**
  * Metadata is a map containing message context,
@@ -8,7 +9,7 @@ import { Matcher } from './matchers';
  * @module Message
  */
 export interface Metadata {
-  [name: string]: string | Matcher<string>;
+  [name: string]: string | Matcher<string> | MatcherV3<string>;
 }
 
 /**

--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -169,10 +169,7 @@ export class MessageConsumerPact {
     }
 
     forEachObjIndexed((v, k) => {
-      this.message.withMetadata(
-        `${k}`,
-        typeof v === 'string' ? v : v.getValue()
-      );
+      this.message.withMetadata(`${k}`, JSON.stringify(v));
     }, metadata);
 
     return this;

--- a/src/v4/message/index.ts
+++ b/src/v4/message/index.ts
@@ -28,6 +28,7 @@ import {
   generateMockServerError,
 } from '../../v3/display';
 import logger from '../../common/logger';
+import { isMatcher as isV3Matcher } from '../../v3/matchers';
 
 const defaultPactDir = './pacts';
 
@@ -188,10 +189,7 @@ export class SynchronousMessageWithResponseBuilder
     }
 
     forEachObjIndexed((v, k) => {
-      this.interaction.withMetadata(
-        `${k}`,
-        typeof v === 'string' ? v : v.getValue()
-      );
+      this.interaction.withMetadata(`${k}`, JSON.stringify(v));
     }, metadata);
 
     return this;


### PR DESCRIPTION
Metadata _values_ always had their matchers stripped off. Once the matchers (integration JSON) were able to be passed in, we needed to update the core (https://github.com/pact-foundation/pact-js-core/pull/493) to use the latest metadata FFI method, which allowed this structure to be passed in.

Fixes #1133
Fixes #745 
