### PR TITLE
feat: support matching numbers, bool in query strings

### DIFF
--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -125,7 +125,9 @@ export declare type TemplateHeaders = {
 
 export type TemplateQuery = Record<
   string,
-  string | Matcher<string> | Array<string | Matcher<string>>
+  | string
+  | Matcher<string | number | boolean>
+  | Array<string | Matcher<string | number | boolean>>
 >;
 
 export interface V3Interaction {


### PR DESCRIPTION
In reviewing the query DSL, we are only allowing matching on `string` values or matchers that work on strings.

However, the matching capability actually does extend to checking the types of query parameters, even if their underlying representation in is a string.

This change allows both `boolean` and `number` types to be used in matching rules.

In a future change, we should also support the ability to have empty and no values (as per https://github.com/pact-foundation/pact-reference/pull/411).