### PR TITLE
fix: fromProviderState incorrectly was a type matcher

### DIFF
--- a/src/v3/matchers.ts
+++ b/src/v3/matchers.ts
@@ -496,7 +496,7 @@ export function fromProviderState<V>(
   exampleValue: V
 ): ProviderStateInjectedValue<V> {
   return {
-    'pact:matcher:type': 'type',
+    'pact:matcher:type': '', // TODO: split generators out from matchers in next major release
     'pact:generator:type': 'ProviderState',
     expression,
     value: exampleValue,

--- a/src/v3/types.ts
+++ b/src/v3/types.ts
@@ -33,7 +33,7 @@ export type AnyTemplate =
  */
 export interface Matcher<T> {
   'pact:matcher:type': string;
-  'pact:generator:type'?: string;
+  'pact:generator:type'?: string; // In the future, we should split out generator from matchers (they are different things)
   value?: T | Record<string, T>;
 }
 


### PR DESCRIPTION
Fixes #1088 

This is an unfortunate solution, but works. It exposes a type/logic flaw, in that generators are considered a type of Matcher, which they are not. This should be rectified in a future major release.