### PR TITLE
Feat/support alpine

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,6 @@ jobs:
         os: [macos-14, macos-12, ubuntu-latest, windows-latest]
         docker: [false]
         alpine: [false]
-        arch: [amd64]
         include:
           - os: ubuntu-latest
             docker: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,111 +15,105 @@ env:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16, 18, 20, 22]
         os: [macos-14, macos-12, ubuntu-latest, windows-latest]
+        docker: [false]
+        alpine: [false]
+        arch: [amd64]
+        include:
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: amd64
+            node-version: 22
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: amd64
+            node-version: 20
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: amd64
+            node-version: 18
+          # ARM64 Builds under Qemu
+          - os: ubuntu-latest
+            docker: true
+            alpine: false
+            arch: arm64
+            node-version: 22
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: arm64
+            node-version: 22
+          - os: ubuntu-latest
+            docker: true
+            alpine: false
+            arch: arm64
+            node-version: 20
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: arm64
+            node-version: 20
+          - os: ubuntu-latest
+            docker: true
+            alpine: true
+            arch: arm64
+            node-version: 18
+    name: Test ${{ matrix.docker == true && matrix.alpine == true && 'linux-musl' || matrix.docker == true && matrix.alpine == false && 'linux' || matrix.os }}-${{ matrix.arch }}-node-${{ matrix.node-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: bash scripts/ci/build-and-test.sh
-        shell: bash
+
+      - run: scripts/ci/build-and-test.sh
+        if: ${{ matrix.docker != true }}
+
+      - name: Set up QEMU
+        if: ${{ matrix.docker == true && matrix.arch == 'arm64' }}
+        uses: docker/setup-qemu-action@v3
+
+      - if: ${{ matrix.docker == true && matrix.alpine != true && matrix.arch == 'arm64' }}
+        name: test linux ${{ matrix.arch }} glibc
+        run: |
+          npm run docker:debian:build
+          npm run docker:debian:run
         env:
+          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
+          NODE_VERSION: ${{ matrix.node-version }}
+          GITHUB_ACTIONS: ${{ env.GITHUB_ACTIONS }}
           SKIP_EXAMPLES: true
-      - run: scripts/ci/test-examples.sh
-        shell: bash
+
+      - if: ${{ matrix.docker == true && matrix.alpine == true && matrix.arch == 'amd64' }}
+        name: test linux ${{ matrix.arch }} musl
+        run: |
+          npm run docker:alpine:build
+          npm run docker:alpine:run
         env:
-          SETUP_DIST_ONLY: true
+          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
+          NODE_VERSION: ${{ matrix.node-version }}
+          GITHUB_ACTIONS: ${{ env.GITHUB_ACTIONS }}
 
-      ## require jest-pact and mocha-pact to update peer deps
-      # - name: example_mocha
-      #   run: cd examples/mocha && npm install --ignore-scripts && npm test
-      # - name: example_jest
-      #   run: cd examples/jest && npm install --ignore-scripts && npm test
-
-      #  passing
-      - name: example_e2e
-        run: cd examples/e2e && npm install --ignore-scripts && npm test
-      - name: example_graphql
-        run: cd examples/graphql && npm install --ignore-scripts && npm test
-      - name: example_messages
-        run: cd examples/messages && npm install --ignore-scripts && npm test
-      - name: example_serverless
-        run: cd examples/serverless && npm install --ignore-scripts && npm test
-      - name: example_typescript
-        run: cd examples/typescript && npm install --ignore-scripts && npm test
-      - name: example_v3_e2e
-        run: cd examples/v3/e2e && npm install --ignore-scripts && npm test
-      - name: example_v3_provider-state-injected
-        run: cd examples/v3/provider-state-injected && npm install --ignore-scripts && npm test
-      - name: example_v3_run-specific-verifications
-        run: cd examples/v3/run-specific-verifications && npm install --ignore-scripts && npm test
-      - name: example_v3_todo-consumer
-        run: cd examples/v3/todo-consumer && npm install --ignore-scripts && npm test
-      - name: example_v3_typescript
-        run: cd examples/v3/typescript && npm install --ignore-scripts && npm test
-      - name: example_v4_plugins
-        run: cd examples/v4/plugins && npm install --ignore-scripts && npm test
-      - name: example_v4_matchers
-        run: cd examples/v4/matchers && npm install --ignore-scripts && npm test
-      # - name: Upload dist folder
-      #   if: runner.os == 'Linux'
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     path: dist
-
-  # examples:
-  #   needs: [build-and-test]
-  #   strategy:
-  #     matrix:
-  #       node-version: [16,18,20]
-  #       os: [macos-latest, ubuntu-latest, windows-latest]
-  #       example:
-  #         [
-  #           e2e,
-  #           graphql,
-  #           jest, # requires jest-pact updating
-  #           messages,
-  #           mocha, # requires mocha-pact updating
-  #           serverless,
-  #           typescript,
-  #           v3/e2e,
-  #           v3/provider-state-injected,
-  #           v3/run-specific-verifications,
-  #           v3/todo-consumer,
-  #           v3/typescript,
-  #           v4/plugins,
-  #         ]
-  #     fail-fast: false
-  #   runs-on: ${{ matrix.os }}
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Download dist folder
-  #       uses: actions/download-artifact@v3
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - run: scripts/ci/test-examples.sh
-  #       shell: bash
-  #       env:
-  #         SETUP_DIST_ONLY: true
-  #       if: matrix.example != 'jest' || matrix.example != 'mocha'
-  #     - run: bash scripts/install-plugins.sh
-  #       if: matrix.example == 'v4/plugins'
-  #     - name: run example ${{ matrix.example }}
-  #       run: |
-  #         npm install --ignore-scripts
-  #         npm test
-  #       shell: bash
-  #       working-directory: examples/${{ matrix.example }}
+      - if: ${{ matrix.docker == true && matrix.alpine == true && matrix.arch == 'arm64' }}
+        name: test linux ${{ matrix.arch }} musl
+        run: |
+          npm run docker:alpine:build
+          npm run docker:alpine:run
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
+          NODE_VERSION: ${{ matrix.node-version }}
+          GITHUB_ACTIONS: ${{ env.GITHUB_ACTIONS }}
+          SKIP_EXAMPLES: true

--- a/.github/workflows/publish-9x.yml
+++ b/.github/workflows/publish-9x.yml
@@ -9,11 +9,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: 9.x.x
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,11 @@ jobs:
     outputs:
       version: v${{ steps.publish.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,9 @@
+ARG NODE_VERSION=current
+FROM node:${NODE_VERSION}-alpine
+
+RUN apk add bash curl git file libc6-compat gcompat jq
+# libc6-compat gcompat required for @pact-foundation/pact-cli ruby runtime
+# all other dependencies just used for @pact-foundation/pact testing
+# so you don't need to use those in your own projects
+
+ENTRYPOINT [ "bash", "-c", "scripts/ci/build-and-test.sh" ]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,8 @@
+ARG NODE_VERSION=latest
+FROM node:${NODE_VERSION}-slim
+
+RUN apt-get -y update && apt-get -y install curl git jq
+# dependencies just used for @pact-foundation/pact testing
+# so you don't need to use those in your own projects
+
+ENTRYPOINT [ "bash", "-c", "scripts/ci/build-and-test.sh" ]

--- a/README.md
+++ b/README.md
@@ -250,13 +250,29 @@ It's best to run Pact verification tests as part of your unit testing suite, so 
 
 <details><summary>Specification Compatibility</summary>
 
-| Version | Stable | [Spec] Compatibility | Install            |
-| ------- | ------ | -------------------- | ------------------ |
-| 11.x.x  | Yes    | 2, 3, 4              | See [installation] |
-| 10.x.x  | Yes    | 2, 3, 4              | See [installation] |
-| 9.x.x   | Yes    | 2, 3\*               | [9xx]              |
+| Version  | Stable | [Spec] Compatibility | Install            |
+| -------  | ------ | -------------------- | ------------------ |
+| 11.x.x + | Yes    | 2, 3, 4              | See [installation] |
+| 10.x.x   | Yes    | 2, 3, 4              | See [installation] |
+| 9.x.x    | Yes    | 2, 3\*               | [9xx]              |
 
 _\*_ v3 support is limited to the subset of functionality required to enable language inter-operable [Message support].
+
+</details>
+
+<details><summary>Supported Platforms</summary>
+
+| OS            | Architecture | Supported  | Pact-JS Version  |
+| ------------- | ------------ | ---------  | ---------------- |
+| MacOS         | x86_64       | ✅         | All              |
+| MacOS         | arm64        | ✅         | 9.x +            |
+| Linux (libc)  | x86_64       | ✅         | All              |
+| Linux (libc)  | arm64        | ✅         | 10.x +           |
+| Linux (musl)  | x86_64       | ✅         | 13.x +           |
+| Linux (musl)  | arm64        | ✅         | 13.x +           |
+| Windows       | x86_64       | ✅         | All              |
+| Windows       | x86          | ❌         | 9.x -            |
+| Windows       | arm64        | ❌         | -                |
 
 </details>
 

--- a/examples/e2e/package-lock.json
+++ b/examples/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@pact-foundation/pact": "file:../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "absolute-version": "1.0.1",
         "body-parser": "^1.20.0",
         "chai": "^4.3.6",
@@ -110,9 +110,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -3173,9 +3173,9 @@
       }
     },
     "@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2",

--- a/examples/e2e/package-lock.json
+++ b/examples/e2e/package-lock.json
@@ -26,11 +26,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -47,7 +47,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -3108,7 +3108,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -3161,7 +3161,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/e2e/package.json
+++ b/examples/e2e/package.json
@@ -4,6 +4,7 @@
   "description": "Pact JS E2E Example",
   "scripts": {
     "test": "npm run test:consumer && npm run test:publish && npm run test:provider",
+    "test:no:publish": "npm run test:consumer && npm run test:provider",
     "test:consumer": "mocha test/consumer.spec.js",
     "test:publish": "pact-broker publish ./pacts --consumer-app-version=\"$(npx absolute-version)\" --auto-detect-version-properties --broker-base-url=https://test.pactflow.io --broker-username dXfltyFMgNOFZAxr8io9wJ37iUpY42M --broker-password O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
     "test:provider": "mocha test/provider.spec.js",
@@ -19,7 +20,7 @@
   "devDependencies": {
     "absolute-version": "1.0.1",
     "@pact-foundation/pact": "file:../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "body-parser": "^1.20.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -36,11 +36,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -57,7 +57,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -1466,22 +1466,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1492,12 +1476,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1801,9 +1785,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -2030,17 +2014,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2071,61 +2055,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -2154,9 +2083,9 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2620,6 +2549,22 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -4077,22 +4022,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
@@ -4362,22 +4291,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/ms": {

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@pact-foundation/pact": "file:../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "@types/chai": "^4.3.8",
         "@types/chai-as-promised": "7.1.6",
         "@types/mocha": "^10.0.2",
@@ -905,9 +905,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "clean": "rimraf pacts",
     "test": "npm run clean && npm run test:consumer && npm run test:publish && npm run test:provider",
+    "test:no:publish": "npm run test:consumer && npm run test:provider",
     "test:consumer": "nyc --reporter=text-summary mocha src/consumer.spec.ts",
     "test:publish": "pact-broker publish ./pacts --consumer-app-version=\"$(npx absolute-version)\" --auto-detect-version-properties --broker-base-url=https://test.pactflow.io --broker-username dXfltyFMgNOFZAxr8io9wJ37iUpY42M --broker-password O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
     "test:provider": "nyc --reporter=text-summary mocha -t 30000 src/provider.spec.ts"
@@ -20,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@pact-foundation/pact": "file:../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "@types/chai": "^4.3.8",
     "@types/chai-as-promised": "7.1.6",
     "@types/mocha": "^10.0.2",

--- a/examples/jest/package-lock.json
+++ b/examples/jest/package-lock.json
@@ -14,17 +14,17 @@
         "absolute-version": "1.0.2",
         "axios": "^1.6.5",
         "jest": "^29.7.0",
-        "jest-pact": "^0.11.0",
+        "jest-pact": "^0.11.1",
         "rimraf": "5.0.5"
       }
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -41,7 +41,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -3251,15 +3251,15 @@
       }
     },
     "node_modules/jest-pact": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.0.tgz",
-      "integrity": "sha512-Q1bhtmTRuVsfmjA21D4nqbqE7IVR16x1Qy9QkDZh2NQrrelTmxfdMeE2rHy5iGTxiNyV18d2JcXGNgcogAMfEg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.1.tgz",
+      "integrity": "sha512-lpdHsznU+SthRgdee/Kqbk6z0nmieqFh/BuYlFCPD9gsuELpxckXiXX9tvY9OWb3CGDoTMEQFo3R6cPH4JwjKw==",
       "dev": true,
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0",
+        "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0 || ^13.0.0",
         "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0"
       }
     },
@@ -5868,7 +5868,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -5921,7 +5921,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",
@@ -7391,9 +7391,9 @@
       }
     },
     "jest-pact": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.0.tgz",
-      "integrity": "sha512-Q1bhtmTRuVsfmjA21D4nqbqE7IVR16x1Qy9QkDZh2NQrrelTmxfdMeE2rHy5iGTxiNyV18d2JcXGNgcogAMfEg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.1.tgz",
+      "integrity": "sha512-lpdHsznU+SthRgdee/Kqbk6z0nmieqFh/BuYlFCPD9gsuELpxckXiXX9tvY9OWb3CGDoTMEQFo3R6cPH4JwjKw==",
       "dev": true,
       "requires": {}
     },

--- a/examples/jest/package-lock.json
+++ b/examples/jest/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@pact-foundation/pact": "file:../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "absolute-version": "1.0.2",
         "axios": "^1.6.5",
         "jest": "^29.7.0",
@@ -1274,9 +1274,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -5933,9 +5933,9 @@
       }
     },
     "@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2",

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -17,7 +17,7 @@
     "@pact-foundation/pact-cli": "^15.0.1",
     "axios": "^1.6.5",
     "jest": "^29.7.0",
-    "jest-pact": "^0.11.0",
+    "jest-pact": "^0.11.1",
     "rimraf": "5.0.5"
   }
 }

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "absolute-version": "1.0.2",
     "@pact-foundation/pact": "file:../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "axios": "^1.6.5",
     "jest": "^29.7.0",
     "jest-pact": "^0.11.1",

--- a/examples/messages/package-lock.json
+++ b/examples/messages/package-lock.json
@@ -23,11 +23,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -44,7 +44,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -2294,7 +2294,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -2347,7 +2347,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/messages/package-lock.json
+++ b/examples/messages/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@pact-foundation/pact": "file:../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "@types/mocha": "^9.1.1",
         "@types/node": "^18.7.11",
         "absolute-version": "1.0.1",
@@ -144,9 +144,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -2359,9 +2359,9 @@
       }
     },
     "@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2",

--- a/examples/messages/package.json
+++ b/examples/messages/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "clean": "rimraf pacts",
     "test": "npm run test:consumer && npm run test:publish && npm run test:provider",
+    "test:no:publish": "npm run test:consumer && npm run test:provider",
     "test:consumer": "mocha consumer/*.spec.ts",
     "test:provider": "mocha -t 20000 provider/*.spec.ts",
     "test:publish": "pact-broker publish ./pacts --consumer-app-version=\"$(npx absolute-version)\" --auto-detect-version-properties --broker-base-url=https://test.pactflow.io --broker-username dXfltyFMgNOFZAxr8io9wJ37iUpY42M --broker-password O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
@@ -16,7 +17,7 @@
   "devDependencies": {
     "absolute-version": "1.0.1",
     "@pact-foundation/pact": "file:../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.7.11",
     "axios": "^1.6.5",

--- a/examples/mocha/package-lock.json
+++ b/examples/mocha/package-lock.json
@@ -18,11 +18,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -39,7 +39,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -1281,7 +1281,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -1334,7 +1334,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/serverless/package-lock.json
+++ b/examples/serverless/package-lock.json
@@ -22,11 +22,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -43,7 +43,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -6424,9 +6424,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -6684,7 +6684,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -6737,7 +6737,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",
@@ -11553,9 +11553,9 @@
       }
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
     },

--- a/examples/serverless/package-lock.json
+++ b/examples/serverless/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@pact-foundation/pact": "file:../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "absolute-version": "1.0.1",
         "aws-sdk": "^2.1354.0",
         "chai": "^4.3.6",
@@ -156,9 +156,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -6749,9 +6749,9 @@
       }
     },
     "@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2",

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "rimraf pacts",
     "test": "npm run test:consumer && npm run test:publish && npm run test:provider",
+    "test:no:publish": "npm run test:consumer && npm run test:provider",
     "test:consumer": "mocha consumer/*.spec.js",
     "test:provider": "mocha -t 30000 provider/*.spec.js",
     "test:publish": "pact-broker publish ./pacts --consumer-app-version=\"$(npx absolute-version)\" --auto-detect-version-properties --broker-base-url=https://test.pactflow.io --broker-username dXfltyFMgNOFZAxr8io9wJ37iUpY42M --broker-password O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
@@ -20,7 +21,7 @@
   "devDependencies": {
     "absolute-version": "1.0.1",
     "@pact-foundation/pact": "file:../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "aws-sdk": "^2.1354.0",
     "chai": "^4.3.6",
     "lodash": "^4.17.21",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -30,11 +30,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -51,7 +51,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -3632,7 +3632,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -3685,7 +3685,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v3/e2e/package-lock.json
+++ b/examples/v3/e2e/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@pact-foundation/pact": "file:../../../dist",
-        "@pact-foundation/pact-cli": "^15.0.1",
+        "@pact-foundation/pact-cli": "^15.0.2",
         "absolute-version": "1.0.1",
         "body-parser": "^1.20.0",
         "chai": "^3.5.0",
@@ -271,9 +271,9 @@
       "link": true
     },
     "node_modules/@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "cpu": [
         "x64",
         "ia32",
@@ -4679,9 +4679,9 @@
       }
     },
     "@pact-foundation/pact-cli": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.1.tgz",
-      "integrity": "sha512-hr58QIbF6gQTcHEsLZRdPYkRWv4eBJ5uZNOTUHLnGZCTn7Vt0KwbSvQzfCryoHTJuj30lgjWVwFQidvUAGeBWg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-15.0.2.tgz",
+      "integrity": "sha512-vJ5lFrBO2YMYY+CR+niqeRMtM3yNk5KRJPrrWqiReDYaUayqBNKsZd2le8QlKqL43dlHPw/Hw4ZfX9BJgT0VGQ==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2",

--- a/examples/v3/e2e/package-lock.json
+++ b/examples/v3/e2e/package-lock.json
@@ -34,11 +34,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -55,7 +55,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -4614,7 +4614,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -4667,7 +4667,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v3/e2e/package.json
+++ b/examples/v3/e2e/package.json
@@ -4,6 +4,7 @@
   "description": "Pact JS E2E Example",
   "scripts": {
     "test": "npm run test:consumer && npm run test:publish && npm run test:provider",
+    "test:no:publish": "npm run test:consumer && npm run test:provider",
     "test:consumer": "mocha --config=test/.mocharc.json test/consumer.spec.js",
     "test:publish": "pact-broker publish ./pacts --consumer-app-version=\"$(npx absolute-version)\" --auto-detect-version-properties --broker-base-url=https://test.pactflow.io --broker-username dXfltyFMgNOFZAxr8io9wJ37iUpY42M --broker-password O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
     "test:provider": "mocha --config=test/.mocharc.json test/provider.spec.js",
@@ -19,7 +20,7 @@
   "devDependencies": {
     "absolute-version": "1.0.1",
     "@pact-foundation/pact": "file:../../../dist",
-    "@pact-foundation/pact-cli": "^15.0.1",
+    "@pact-foundation/pact-cli": "^15.0.2",
     "body-parser": "^1.20.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^7.1.1",

--- a/examples/v3/provider-state-injected/package-lock.json
+++ b/examples/v3/provider-state-injected/package-lock.json
@@ -21,11 +21,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -42,7 +42,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -5323,7 +5323,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -5376,7 +5376,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v3/run-specific-verifications/package-lock.json
+++ b/examples/v3/run-specific-verifications/package-lock.json
@@ -33,11 +33,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -54,7 +54,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -4251,7 +4251,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -4304,7 +4304,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v3/todo-consumer/package-lock.json
+++ b/examples/v3/todo-consumer/package-lock.json
@@ -29,11 +29,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -50,7 +50,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -2655,7 +2655,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -2708,7 +2708,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v3/todo-consumer/src/todo.js
+++ b/examples/v3/todo-consumer/src/todo.js
@@ -7,10 +7,6 @@ const parser = new XMLParser({
   ignoreAttributes: false,
 });
 let serverUrl = 'http://127.0.0.1:2203';
-const HasBinaryPayloadIssue =
-  process.platform === 'win32' ||
-  (process.platform === 'darwin' && process.arch === 'arm64') ||
-  (process.platform === 'linux' && process.arch === 'arm64');
 
 module.exports = {
   getProjects: async (format = 'json') => {
@@ -44,9 +40,7 @@ module.exports = {
     const data = fs.readFileSync(image);
     return axios.post(serverUrl + '/projects/' + id + '/images', data, {
       headers: {
-        'Content-Type': HasBinaryPayloadIssue
-          ? 'application/octet-stream'
-          : 'image/jpeg',
+        'Content-Type': 'image/jpeg',
       },
     });
   },

--- a/examples/v3/todo-consumer/test/consumer.spec.js
+++ b/examples/v3/todo-consumer/test/consumer.spec.js
@@ -8,10 +8,6 @@ const LOG_LEVEL = process.env.LOG_LEVEL || 'TRACE';
 
 const TodoApp = require('../src/todo');
 const expect = chai.expect;
-const HasBinaryPayloadIssue =
-  process.platform === 'win32' ||
-  (process.platform === 'darwin' && process.arch === 'arm64') ||
-  (process.platform === 'linux' && process.arch === 'arm64');
 chai.use(chaiAsPromised);
 
 describe('Pact V3', () => {
@@ -148,7 +144,6 @@ describe('Pact V3', () => {
       });
     });
 
-    // See https://github.com/pact-foundation/pact-reference/issues/171 for why it's skipped
     describe('with image uploads', () => {
       before(() => {
         provider
@@ -156,7 +151,7 @@ describe('Pact V3', () => {
           .uponReceiving('a request to store an image against the project')
           .withRequestBinaryFile(
             { method: 'POST', path: '/projects/1001/images' },
-            HasBinaryPayloadIssue ? 'application/octet-stream' : 'image/jpeg',
+            'image/jpeg',
             path.resolve(__dirname, 'example.jpg')
           )
           .willRespondWith({ status: 201 });

--- a/examples/v3/typescript/package-lock.json
+++ b/examples/v3/typescript/package-lock.json
@@ -31,11 +31,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -52,7 +52,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -3714,7 +3714,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -3767,7 +3767,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/examples/v4/matchers/package-lock.json
+++ b/examples/v4/matchers/package-lock.json
@@ -25,11 +25,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -46,7 +46,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {

--- a/examples/v4/plugins/package-lock.json
+++ b/examples/v4/plugins/package-lock.json
@@ -25,11 +25,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "12.5.0",
+      "version": "13.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -46,7 +46,7 @@
         "lodash.isundefined": "3.0.1",
         "lodash.omit": "^4.5.0",
         "pkginfo": "^0.4.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3"
       },
       "devDependencies": {
@@ -2543,7 +2543,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",
@@ -2596,7 +2596,7 @@
         "pkginfo": "^0.4.1",
         "prettier": "^2.7.1",
         "proxyquire": "^2.0.1",
-        "ramda": "^0.28.0",
+        "ramda": "^0.30.0",
         "randexp": "^0.5.3",
         "rimraf": "^2.7.1",
         "sinon": "^7.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.0.0",
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.0.0",
+        "@pact-foundation/pact-core": "^15.1.0",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.0.0.tgz",
-      "integrity": "sha512-XkF/xe5BL9ev4D2AVZpmvYIp30Kg1sKNlCYVwMAeuHCiHhE7pPBgwZIwIXdIGplnwK78E1ZPFsbla3zwhjQ/bw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.0.tgz",
+      "integrity": "sha512-svMJQtzSLi4a/O1ZFHWsiIvLcxanCT9f0IYMktRfs+F87eJ+HjjrwPieBp0nGJQASJYZLOec0ZHhpG/nQ3366w==",
       "cpu": [
         "x64",
         "ia32",
@@ -12592,9 +12592,9 @@
       }
     },
     "@pact-foundation/pact-core": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.0.0.tgz",
-      "integrity": "sha512-XkF/xe5BL9ev4D2AVZpmvYIp30Kg1sKNlCYVwMAeuHCiHhE7pPBgwZIwIXdIGplnwK78E1ZPFsbla3zwhjQ/bw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.0.tgz",
+      "integrity": "sha512-svMJQtzSLi4a/O1ZFHWsiIvLcxanCT9f0IYMktRfs+F87eJ+HjjrwPieBp0nGJQASJYZLOec0ZHhpG/nQ3366w==",
       "requires": {
         "check-types": "7.3.0",
         "node-gyp-build": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-core": "^15.0.0",
+    "@pact-foundation/pact-core": "^15.1.0",
     "@types/express": "^4.17.11",
     "axios": "^1.6.1",
     "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
     "predist": "npm run clean && npm run format:check && npm run lint",
     "release": "commit-and-tag-version",
     "test": "nyc --check-coverage --reporter=html --reporter=text-summary mocha -t 120000",
-    "pretest": "bash scripts/install-plugins.sh"
+    "pretest": "bash scripts/install-plugins.sh",
+    "docker:alpine:build": "docker build --build-arg NODE_VERSION=${NODE_VERSION:-current} -f Dockerfile.alpine -t pact-js:alpine .",
+    "docker:debian:build": "docker build --build-arg NODE_VERSION=${NODE_VERSION:-current} -f Dockerfile.debian -t pact-js:debian .",
+    "docker:alpine:run": "docker run -e LOG_LEVEL=${LOG_LEVEL:-info} -e GIT_REF=${GIT_REF:-test} -e GITHUB_ACTIONS=${GITHUB_ACTIONS:-false} -e SKIP_EXAMPLES=${SKIP_EXAMPLES:-''} -w /home -v $(pwd):/home --rm pact-js:alpine",
+    "docker:debian:run": "docker run -e LOG_LEVEL=${LOG_LEVEL:-info} -e GIT_REF=${GIT_REF:-test} -e GITHUB_ACTIONS=${GITHUB_ACTIONS:-false} -e SKIP_EXAMPLES=${SKIP_EXAMPLES:-''} -w /home -v $(pwd):/home --rm pact-js:debian",
+    "docker:alpine:attach": "docker run -w /home -v $(pwd):/home --entrypoint /bin/bash --rm -it pact-js:alpine",
+    "docker:debian:attach": "docker run -w /home -v $(pwd):/home --entrypoint /bin/bash --rm -it pact-js:debian"
   },
   "repository": {
     "type": "git",

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -6,7 +6,7 @@ set -x
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the script is running
 . "$SCRIPT_DIR"/lib/robust-bash.sh
 
-npm ci --ignore-scripts
+npm ci
 
 npm run dist
 cp package.json ./dist

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the 
 
 # Link the build so that the examples are always testing the
 # current build, in it's properly exported format
-(cd dist && npm ci --ignore-scripts)
+(cd dist && npm ci)
 
 echo "Running e2e examples build for node version $(node --version)"
 for i in examples/*; do
@@ -23,8 +23,12 @@ for i in examples/*; do
     if [ x"${SETUP_DIST_ONLY:-}" == "x" ]; then 
       echo "running all examples as SETUP_DIST_ONLY not set"
     # npm ci does not work because we have just changed the package.json file
-      npm install --ignore-scripts
-      npm test
+      npm install
+      if [[ -f /.dockerenv && "$(uname -sm)" == 'Linux aarch64' && "$GITHUB_ACTIONS" == 'true' ]]; then
+        npm run test:no:publish || npm test
+      else
+        npm test
+      fi
     else
       echo "skipping testing of examples as SETUP_DIST_ONLY set"
     fi
@@ -55,8 +59,12 @@ for i in examples/v*/*; do
   if [ x"${SETUP_DIST_ONLY:-}" == "x" ]; then 
     echo "running all examples as SETUP_DIST_ONLY not set"
   # npm ci does not work because we have just changed the package.json file
-    npm install --ignore-scripts
-    npm test
+    npm install
+    if [[ -f /.dockerenv && "$(uname -sm)" == 'Linux aarch64' && "$GITHUB_ACTIONS" == 'true' ]]; then
+      npm run test:no:publish || npm test
+    else
+      npm test
+    fi
   else
     echo "skipping testing of examples as SETUP_DIST_ONLY set"
   fi

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -38,7 +38,7 @@ function detect_osarch() {
 }
 
 
-VERSION="0.0.4"
+VERSION="0.1.2"
 detect_osarch
 
 if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then
@@ -48,7 +48,8 @@ if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then
     echo "        Downloading from: ${DOWNLOAD_LOCATION}"
     curl -L -o ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz "${DOWNLOAD_LOCATION}"
     echo "        Downloaded $(file ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz)"
-    gunzip -N -f ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz
+    gunzip -f ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz
+    mv ~/.pact/bin/pact-plugin-cli-${os}-${arch} ~/.pact/bin/pact-plugin-cli
     chmod +x ~/.pact/bin/pact-plugin-cli
 fi
 

--- a/src/common/net.spec.ts
+++ b/src/common/net.spec.ts
@@ -11,7 +11,7 @@ chai.use(chaiAsPromised);
 describe('Net', () => {
   const port = 4567;
   const defaultHost = '0.0.0.0';
-  const specialPort = process.platform.match('win') ? -1 : 80;
+  const specialPort = -1;
 
   // Utility function to create a server on a given port and return a Promise
   const createServer = (p: number, host = defaultHost) =>
@@ -26,9 +26,7 @@ describe('Net', () => {
       });
     });
 
-  (process.platform === 'linux' && process.arch === 'arm64'
-    ? describe.skip
-    : describe)('#isPortAvailable', () => {
+  describe('#isPortAvailable', () => {
     context('when the port is not allowed to be bound', () => {
       it('returns a rejected promise', () =>
         expect(isPortAvailable(specialPort, defaultHost)).to.eventually.be


### PR DESCRIPTION
fixes #1180

Includes https://github.com/pact-foundation/pact-js-core/pull/507 from pact-js-core

- Adds Dockerfiles for debian (glibc) / alpine via node official images
- Tests arm64 / amd64 variants in gha
- allows conditional skipping of publish steps (using ruby binaries as these fail under qemu when emulating arm64 on an x86_64 host)
- skips examples running in arm64 docker builds, as emulation means runs take approx 30 minutes, runs pact-js test suite only 