### PR TITLE
Deps/pact js core 15.1.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [16, 18, 20, 22.4.1]
         os: [macos-14, macos-12, ubuntu-latest, windows-latest]
         docker: [false]
         alpine: [false]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
             docker: true
             alpine: true
             arch: amd64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: true
@@ -46,12 +46,12 @@ jobs:
             docker: true
             alpine: false
             arch: arm64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: true
             arch: arm64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: false

--- a/examples/e2e/package-lock.json
+++ b/examples/e2e/package-lock.json
@@ -26,11 +26,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -3108,7 +3108,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -36,11 +36,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",

--- a/examples/jest/package-lock.json
+++ b/examples/jest/package-lock.json
@@ -20,11 +20,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -5868,7 +5868,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/messages/package-lock.json
+++ b/examples/messages/package-lock.json
@@ -23,11 +23,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -2294,7 +2294,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/mocha/package-lock.json
+++ b/examples/mocha/package-lock.json
@@ -18,11 +18,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -1281,7 +1281,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/serverless/package-lock.json
+++ b/examples/serverless/package-lock.json
@@ -22,11 +22,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -6684,7 +6684,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -30,11 +30,11 @@
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -3632,7 +3632,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v3/e2e/package-lock.json
+++ b/examples/v3/e2e/package-lock.json
@@ -34,11 +34,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -4614,7 +4614,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v3/provider-state-injected/package-lock.json
+++ b/examples/v3/provider-state-injected/package-lock.json
@@ -21,11 +21,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -5323,7 +5323,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v3/run-specific-verifications/package-lock.json
+++ b/examples/v3/run-specific-verifications/package-lock.json
@@ -33,11 +33,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -4251,7 +4251,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v3/todo-consumer/package-lock.json
+++ b/examples/v3/todo-consumer/package-lock.json
@@ -29,11 +29,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -2655,7 +2655,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v3/typescript/package-lock.json
+++ b/examples/v3/typescript/package-lock.json
@@ -31,11 +31,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -3714,7 +3714,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v4/matchers/package-lock.json
+++ b/examples/v4/matchers/package-lock.json
@@ -25,11 +25,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",

--- a/examples/v4/plugins/package-lock.json
+++ b/examples/v4/plugins/package-lock.json
@@ -25,11 +25,11 @@
     },
     "../../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.0.0",
+      "version": "13.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -2543,7 +2543,7 @@
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",
         "@babel/preset-env": "^7.18.6",
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
         "@types/chai": "^4.3.1",
         "@types/chai-as-promised": "^7.1.1",

--- a/examples/v4/plugins/test/matt.consumer.spec.ts
+++ b/examples/v4/plugins/test/matt.consumer.spec.ts
@@ -105,6 +105,7 @@ const sendMattMessageTCP = (
   return new Promise((resolve) => {
     socket.on('data', (data) => {
       resolve(parseMattMessage(data.toString()));
+      socket.destroy();
     });
   });
 };

--- a/examples/v4/plugins/test/matt.consumer.spec.ts
+++ b/examples/v4/plugins/test/matt.consumer.spec.ts
@@ -10,88 +10,81 @@ chai.use(chaiAsPromised);
 
 const { expect } = chai;
 
-(process.platform === 'win32' ? describe.skip : describe)(
-  'Plugins - Matt Protocol',
-  () => {
-    const HOST = '127.0.0.1';
+describe('Plugins - Matt Protocol', () => {
+  const HOST = '127.0.0.1';
 
-    describe('HTTP interface', () => {
-      const pact = new PactV4({
-        consumer: 'myconsumer',
-        provider: 'myprovider',
-        spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
-        logLevel: (process.env.LOG_LEVEL as LogLevel) || 'error',
-      });
-      it('returns a valid MATT message over HTTP', async () => {
-        const mattRequest = `{"request": {"body": "hello"}}`;
-        const mattResponse = `{"response":{"body":"world"}}`;
+  describe('HTTP interface', () => {
+    const pact = new PactV4({
+      consumer: 'myconsumer',
+      provider: 'myprovider',
+      spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
+      logLevel: (process.env.LOG_LEVEL as LogLevel) || 'error',
+    });
+    it('returns a valid MATT message over HTTP', async () => {
+      const mattRequest = `{"request": {"body": "hello"}}`;
+      const mattResponse = `{"response":{"body":"world"}}`;
 
-        await pact
-          .addInteraction()
-          .given('the Matt protocol exists')
-          .uponReceiving('an HTTP request to /matt')
+      await pact
+        .addInteraction()
+        .given('the Matt protocol exists')
+        .uponReceiving('an HTTP request to /matt')
+        .usingPlugin({
+          plugin: 'matt',
+          version: '0.1.1',
+        })
+        .withRequest('POST', '/matt', (builder) => {
+          builder.pluginContents('application/matt', mattRequest);
+        })
+        .willRespondWith(200, (builder) => {
+          builder.pluginContents('application/matt', mattResponse);
+        })
+        .executeTest((mockserver) => {
+          return axios
+            .request({
+              baseURL: mockserver.url,
+              headers: {
+                'content-type': 'application/matt',
+                Accept: 'application/matt',
+              },
+              data: generateMattMessage('hello'),
+              method: 'POST',
+              url: '/matt',
+            })
+            .then((res) => {
+              expect(parseMattMessage(res.data)).to.eq('world');
+            });
+        });
+    });
+  });
+
+  describe('TCP interface', () => {
+    const pact = new PactV4({
+      consumer: 'myconsumer',
+      provider: 'myprovider',
+      spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
+      logLevel: (process.env.LOG_LEVEL as LogLevel) || 'error',
+    });
+
+    describe('with MATT protocol', async () => {
+      it('generates a pact with success', () => {
+        const mattMessage = `{"request": {"body": "hellotcp"}, "response":{"body":"tcpworld"}}`;
+
+        return pact
+          .addSynchronousInteraction('a MATT message')
           .usingPlugin({
             plugin: 'matt',
             version: '0.1.1',
           })
-          .withRequest('POST', '/matt', (builder) => {
-            builder.pluginContents('application/matt', mattRequest);
-          })
-          .willRespondWith(200, (builder) => {
-            builder.pluginContents('application/matt', mattResponse);
-          })
-          .executeTest((mockserver) => {
-            return axios
-              .request({
-                baseURL: mockserver.url,
-                headers: {
-                  'content-type': 'application/matt',
-                  Accept: 'application/matt',
-                },
-                data: generateMattMessage('hello'),
-                method: 'POST',
-                url: '/matt',
-              })
-              .then((res) => {
-                expect(parseMattMessage(res.data)).to.eq('world');
-              });
+          .withPluginContents(mattMessage, 'application/matt')
+          .startTransport('matt', HOST)
+          .executeTest(async (tc) => {
+            const message = await sendMattMessageTCP('hellotcp', HOST, tc.port);
+            expect(message).to.eq('tcpworld');
           });
       });
     });
-
-    describe('TCP interface', () => {
-      const pact = new PactV4({
-        consumer: 'myconsumer',
-        provider: 'myprovider',
-        spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
-        logLevel: (process.env.LOG_LEVEL as LogLevel) || 'error',
-      });
-
-      describe('with MATT protocol', async () => {
-        it('generates a pact with success', () => {
-          const mattMessage = `{"request": {"body": "hellotcp"}, "response":{"body":"tcpworld"}}`;
-
-          return pact
-            .addSynchronousInteraction('a MATT message')
-            .usingPlugin({
-              plugin: 'matt',
-              version: '0.1.1',
-            })
-            .withPluginContents(mattMessage, 'application/matt')
-            .startTransport('matt', HOST)
-            .executeTest(async (tc) => {
-              const message = await sendMattMessageTCP(
-                'hellotcp',
-                HOST,
-                tc.port
-              );
-              expect(message).to.eq('tcpworld');
-            });
-        });
-      });
-    });
-  }
-);
+  });
+});
 
 const sendMattMessageTCP = (
   message: string,

--- a/examples/v4/plugins/test/matt.provider.spec.ts
+++ b/examples/v4/plugins/test/matt.provider.spec.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from 'net';
 import path = require('path');
 import { startHTTPServer, startTCPServer } from '../provider';
 
-(process.platform === 'win32' ? describe.skip : describe)('Plugins', () => {
+describe('Plugins', () => {
   const HOST = '127.0.0.1';
 
   describe('Verification', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.1.1",
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^15.1.0",
+        "@pact-foundation/pact-core": "^15.1.1",
         "@types/express": "^4.17.11",
         "axios": "^1.6.1",
         "body-parser": "^1.20.0",
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.0.tgz",
-      "integrity": "sha512-svMJQtzSLi4a/O1ZFHWsiIvLcxanCT9f0IYMktRfs+F87eJ+HjjrwPieBp0nGJQASJYZLOec0ZHhpG/nQ3366w==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.1.tgz",
+      "integrity": "sha512-JrowGyJ8vEhdLH/k4jovxeqhJh8JxF74ScqSxlRno+DDY7jocizdY3Xb5IzlVESHDyMbqO0AtUydiGjuBwbasw==",
       "cpu": [
         "x64",
         "ia32",
@@ -12592,9 +12592,9 @@
       }
     },
     "@pact-foundation/pact-core": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.0.tgz",
-      "integrity": "sha512-svMJQtzSLi4a/O1ZFHWsiIvLcxanCT9f0IYMktRfs+F87eJ+HjjrwPieBp0nGJQASJYZLOec0ZHhpG/nQ3366w==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.1.1.tgz",
+      "integrity": "sha512-JrowGyJ8vEhdLH/k4jovxeqhJh8JxF74ScqSxlRno+DDY7jocizdY3Xb5IzlVESHDyMbqO0AtUydiGjuBwbasw==",
       "requires": {
         "check-types": "7.3.0",
         "node-gyp-build": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-core": "^15.1.0",
+    "@pact-foundation/pact-core": "^15.1.1",
     "@types/express": "^4.17.11",
     "axios": "^1.6.1",
     "body-parser": "^1.20.0",

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -133,6 +133,7 @@ describe('V4 Pact', () => {
             return new Promise((resolve) => {
               socket.on('data', (data) => {
                 resolve(parseMattMessage(data.toString()));
+                socket.end();
               });
             });
           };

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -133,7 +133,7 @@ describe('V4 Pact', () => {
             return new Promise((resolve) => {
               socket.on('data', (data) => {
                 resolve(parseMattMessage(data.toString()));
-                socket.end();
+                socket.destroy();
               });
             });
           };


### PR DESCRIPTION
Updates to libpact_ffi 0.4.22 via https://github.com/pact-foundation/pact-js-core/pull/519

re-enables matt plugin tests on windows, and adds workaround also applied in above PR