### PR TITLE
chore: correct package homepage link in npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "bugs": {
     "url": "https://github.com/pact-foundation/pact-js/issues"
   },
-  "homepage": "https://docs.pact.io/implementation_guides/javascript/",
+  "homepage": "https://docs.pact.io/implementation_guides/javascript/readme",
   "standard-version": {
     "types": [
       {


### PR DESCRIPTION
## Summary
The homepage link for the `@pact-foundation/pact` package is currently incorrect. It points to https://docs.pact.io/implementation_guides/javascript/, which results in a "Page Not Found" error.

This pull request updates the homepage link to the correct URL: https://docs.pact.io/implementation_guides/javascript/readme.