### PR TITLE
chore: pin only dev dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": [
+    "config:best-practices",
+    ":pinOnlyDevDependencies"
+  ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "automerge": true


### PR DESCRIPTION
To ensure broader compatibility, dependencies of Pact JS should keep using a broad range of versions, with only dev dependencies being pinned to ensure a consistent developer environment.

Ref: https://docs.renovatebot.com/presets-default/#pinonlydevdependencies

Thank you for making a pull request!