### PR TITLE
ci: use arm runners for arm64 workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,16 +172,12 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
         os:
-          - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Set up QEMU
-        if: startsWith(matrix.os, 'ubuntu-')
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3
 
       - name: Setup Node.js ${{ matrix.node-version }}
         if: startsWith(matrix.os, 'macos-')
@@ -200,7 +196,11 @@ jobs:
         run: |
           npm test
 
-      - name: Install dependencies and test
+      - name: Install dependencies and test ubuntu (linux glibc)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: npm ci && npm test
+
+      - name: Install dependencies and test alpine (linux musl)
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
           docker run \


### PR DESCRIPTION
arm64 runners now available, so lets use them to speed up our CI runs

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

the test-arm64 workflow only tested alpine, so the glibc case was not covered.

the test-alpine workflow, using containers as a first class concept in gh actions, unfortunately do not support arm64 yet

```
JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64
```

so this PR 

1. removes qemu on test-arm64 workflows
2. replaces ubuntu-latest (x64) runner with ubuntu-24.04-latest (arm64) runner
3. tests glibc case by running the `npm ci && npm test` workflow on the native ubuntu-24.04-latest (arm64) runner
4. tests musl case by running the existing test step against the alpine image, using the native ubuntu-24.04-latest (arm64) runner