### PR TITLE
chore(release): 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [14.0.0](https://github.com/pact-foundation/pact-js/compare/v13.2.0...v14.0.0) (2025-02-17)
+
+
+### ⚠ BREAKING CHANGES
+
+* **deps:** - Contains platform/architecture specific optional dependencies in pact-core v16+. Users should not need to do anything manually as long as they are running supported platforms
+
+- `linux-x64-glibc`
+- `linux-arm64-glibc`
+- `linux-x64-musl`
+- `linux-arm64-musl`
+- `darwin-x64`
+- `darwin-arm64`
+- `windows-x64`
+
+* **deps:** update pact-core to v16 ([c5ca6ae](https://github.com/pact-foundation/pact-js/commit/c5ca6ae2df1574d7019f7a7262d2a3b964e7a228))
+
+
+### Fixes and Improvements
+
+* code coverage ([c0bb760](https://github.com/pact-foundation/pact-js/commit/c0bb7600d132d22ad1057a74c943993a5e7b23c6))
+* **deps:** update dependency lodash.isfunction to v3.0.9 ([#1268](https://github.com/pact-foundation/pact-js/issues/1268)) ([fb08af3](https://github.com/pact-foundation/pact-js/commit/fb08af37923c8c802ac5d272ee8512307d42f690))
+* examples/graphql/package.json & examples/graphql/package-lock.json to reduce vulnerabilities ([c9ed8fc](https://github.com/pact-foundation/pact-js/commit/c9ed8fcc72e307b787e736fca24dfc130deac880))
+* package.json & package-lock.json to reduce vulnerabilities ([3f535ed](https://github.com/pact-foundation/pact-js/commit/3f535ed070ea837046db7ab59d0418234f33e5d8))
+
 ## [13.2.0](https://github.com/pact-foundation/pact-js/compare/v13.1.5...v13.2.0) (2024-11-21)
 
 

--- a/examples/jest/package-lock.json
+++ b/examples/jest/package-lock.json
@@ -16,13 +16,13 @@
         "@pact-foundation/pact-cli": "^16.0.4",
         "absolute-version": "1.0.2",
         "jest": "^29.7.0",
-        "jest-pact": "^0.11.1",
+        "jest-pact": "^0.11.2",
         "rimraf": "^6.0.1"
       }
     },
     "../../dist": {
       "name": "@pact-foundation/pact",
-      "version": "13.2.0",
+      "version": "14.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -57,7 +57,7 @@
         "@types/sinon-chai": "2.7.42",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
-        "chai": "5.1.2",
+        "chai": "5.2.0",
         "chai-as-promised": "8.0.1",
         "commit-and-tag-version": "12.5.0",
         "copyfiles": "2.4.1",
@@ -3162,15 +3162,16 @@
       }
     },
     "node_modules/jest-pact": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.1.tgz",
-      "integrity": "sha512-lpdHsznU+SthRgdee/Kqbk6z0nmieqFh/BuYlFCPD9gsuELpxckXiXX9tvY9OWb3CGDoTMEQFo3R6cPH4JwjKw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.2.tgz",
+      "integrity": "sha512-a1SPbN7MY2g5gi2kpvkbsSAsVQtkiowh33mYeH9LwDwnB35b3tzbRuWU49EuGldkf0yA5zr+H16IqwDWD6yQbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0 || ^13.0.0",
+        "@pact-foundation/pact": "^v10.0.0-beta.61 || ^10.0.2 || ^11.0.2 || ^12.0.0 || ^13.0.0 || ^14.0.0",
         "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0"
       }
     },
@@ -5807,7 +5808,7 @@
         "@typescript-eslint/parser": "5.62.0",
         "axios": "^1.7.8",
         "body-parser": "^1.20.3",
-        "chai": "5.1.2",
+        "chai": "5.2.0",
         "chai-as-promised": "8.0.1",
         "chalk": "4.1.2",
         "commit-and-tag-version": "12.5.0",
@@ -7235,9 +7236,9 @@
       }
     },
     "jest-pact": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.1.tgz",
-      "integrity": "sha512-lpdHsznU+SthRgdee/Kqbk6z0nmieqFh/BuYlFCPD9gsuELpxckXiXX9tvY9OWb3CGDoTMEQFo3R6cPH4JwjKw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.11.2.tgz",
+      "integrity": "sha512-a1SPbN7MY2g5gi2kpvkbsSAsVQtkiowh33mYeH9LwDwnB35b3tzbRuWU49EuGldkf0yA5zr+H16IqwDWD6yQbg==",
       "dev": true,
       "requires": {}
     },

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -18,7 +18,7 @@
     "@pact-foundation/pact-cli": "^16.0.4",
     "absolute-version": "1.0.2",
     "jest": "^29.7.0",
-    "jest-pact": "^0.11.1",
+    "jest-pact": "^0.11.2",
     "rimraf": "^6.0.1"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pact-foundation/pact",
-  "version": "13.2.0",
+  "version": "14.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pact-foundation/pact",
-      "version": "13.2.0",
+      "version": "14.0.0",
       "license": "MIT",
       "dependencies": {
         "@pact-foundation/pact-core": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pact-foundation/pact",
-  "version": "13.2.0",
+  "version": "14.0.0",
   "description": "Pact for all things Javascript",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",


### PR DESCRIPTION
correcting changelog & version which failed to update in the last release.

relates to #1372 

can't push straight to master (neither can CI on release), due to restriction of test completion check.

CI is impacted, as release workflow is kicked off manually, and does not trigger the test workflow, and therefore completion check. 

the release workflow itself, does perform tests prior to release, so maybe these need to be hooked up to the test completion check 🤷🏾‍♂️ 