### PR TITLE
feat: V4 Asynchronous Messages (issue #1186)

### DIFF
--- a/src/v4/consumer.spec.ts
+++ b/src/v4/consumer.spec.ts
@@ -1,0 +1,92 @@
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { LogLevel } from '@pact-foundation/pact-core';
+import axios from 'axios';
+import { SpecificationVersion, MatchersV3 } from '../v3';
+import { PactV4 } from '.';
+
+chai.use(chaiAsPromised);
+
+const { expect } = chai;
+
+process.env.ENABLE_FEATURE_V4 = 'true';
+
+describe('V4ConsumerPact', () => {
+  const pact = new PactV4({
+    consumer: 'mymessageconsumer',
+    provider: 'mymessageprovider',
+    spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
+    logLevel: (process.env.LOG_LEVEL as LogLevel) || 'trace',
+  });
+
+  describe('httpInteraction', () => {
+    it('passes', async () => {
+      await pact
+        .addInteraction()
+        .uponReceiving('a request only checks the keys and ignores the values')
+        .withRequest('GET', '/')
+        .willRespondWith(200, (builder) => {
+          builder.jsonBody({
+            key1: MatchersV3.string("a string we don't care about"),
+            key2: 1,
+          });
+        })
+        .executeTest((mockserver) =>
+          axios
+            .request({
+              baseURL: mockserver.url,
+              method: 'GET',
+              url: '/',
+            })
+            .then((res) => {
+              expect(res.data.key1).to.equal("a string we don't care about");
+              expect(res.data.key2).to.equal(1);
+            })
+        );
+    });
+  });
+
+  describe('synchronousMessageInteraction', () => {
+    it('passes', async () => {
+      await pact
+        .addSynchronousInteraction('a synchronous message')
+        .given('a test')
+        .withRequest((builder) => {
+          builder.withJSONContent({
+            key1: MatchersV3.string('request string'),
+            key2: 1,
+          });
+        })
+        .withResponse((builder) => {
+          builder.withJSONContent({
+            key1: MatchersV3.string('response string'),
+            key2: 1,
+          });
+        })
+        .executeTest(async () => {});
+    });
+  });
+
+  describe('asynchronousMessageInteraction', () => {
+    it('passes', () => {
+      pact
+        .addAsynchronousInteraction('an asynchronous message')
+        .given('a test')
+        .expectsToReceive('an asynchronous message')
+        .withContents({
+          messageId: '1234',
+          messageBody: {
+            value: 'expected',
+          },
+        })
+        .executeTest(async (message) => {
+          expect(message).to.deep.equal({
+            messageId: '1234',
+            messageBody: {
+              value: 'expected',
+            },
+          });
+        });
+    });
+  });
+});

--- a/src/v4/index.ts
+++ b/src/v4/index.ts
@@ -3,8 +3,14 @@ import { UnconfiguredInteraction } from './http';
 import { PactV4Options, V4UnconfiguredInteraction } from './http/types';
 import { V4ConsumerPact } from './types';
 import { version as pactPackageVersion } from '../../package.json';
-import { V4UnconfiguredSynchronousMessage } from './message/types';
-import { UnconfiguredSynchronousMessage } from './message';
+import {
+  V4UnconfiguredSynchronousMessage,
+  V4UnconfiguredAsynchronousMessage,
+} from './message/types';
+import {
+  UnconfiguredSynchronousMessage,
+  UnconfiguredAsynchronousMessage,
+} from './message';
 import { SpecificationVersion } from '../v3';
 
 export class PactV4 implements V4ConsumerPact {
@@ -49,6 +55,19 @@ export class PactV4 implements V4ConsumerPact {
         // This function needs to be called if the PactV4 object is to be re-used (commonly expected by users)
         // Because of the type-state model used here, it's a bit awkward as we need to thread this through
         // to children, ultimately to be called on the "executeTest" stage.
+        this.setup();
+      }
+    );
+  }
+
+  addAsynchronousInteraction(
+    description: string
+  ): V4UnconfiguredAsynchronousMessage {
+    return new UnconfiguredAsynchronousMessage(
+      this.pact,
+      this.pact.newAsynchronousMessage(description),
+      this.opts,
+      () => {
         this.setup();
       }
     );

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -100,3 +100,21 @@ export interface V4SynchronousMessageWithResponse {
     integrationTest: (m: SynchronousMessage) => Promise<T>
   ): Promise<T | undefined>;
 }
+
+// ASYNCHRONOUS
+
+export interface V4UnconfiguredAsynchronousMessage {
+  given(state: string, parameters?: JsonMap): V4UnconfiguredAsynchronousMessage;
+  usingPlugin(config: PluginConfig): V4UnconfiguredAsynchronousMessage;
+  expectsToReceive(description: string): V4AsynchronousMessage;
+}
+
+export interface V4AsynchronousMessage {
+  withContents(contents: unknown): V4AsynchronousMessageWithContents;
+}
+
+export interface V4AsynchronousMessageWithContents {
+  executeTest<T>(
+    integrationTest: (m: unknown) => Promise<T>
+  ): Promise<T | undefined>;
+}

--- a/src/v4/types.ts
+++ b/src/v4/types.ts
@@ -1,9 +1,15 @@
 import { V4UnconfiguredInteraction } from './http/types';
-import { V4UnconfiguredSynchronousMessage } from './message/types';
+import {
+  V4UnconfiguredSynchronousMessage,
+  V4UnconfiguredAsynchronousMessage,
+} from './message/types';
 
 export interface V4ConsumerPact {
   addInteraction(): V4UnconfiguredInteraction;
   addSynchronousInteraction(
     description: string
   ): V4UnconfiguredSynchronousMessage;
+  addAsynchronousInteraction(
+    description: string
+  ): V4UnconfiguredAsynchronousMessage;
 }


### PR DESCRIPTION
- [x] `npm run dist` works locally (this will run tests, lint and build)
- [x] Commit messages are ready to go in the changelog (see below for details)
- [x] PR template filled in (see below for details)

This PR adds support for [AsynchronousMessages to the V4 Pact](https://github.com/pact-foundation/pact-js/issues/1186)
