### PR TITLE
docs: update npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Learn the key Pact JS features in 60 minutes: https://github.com/pact-foundation
 ## Installation
 
 ```shell
-npm i -S @pact-foundation/pact@latest
+npm i @pact-foundation/pact@latest
 
 # 🚀 now write some tests!
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Learn the key Pact JS features in 60 minutes: https://github.com/pact-foundation
 ## Installation
 
 ```shell
-npm i @pact-foundation/pact@latest
+npm install --save-dev @pact-foundation/pact
 
 # 🚀 now write some tests!
 ```


### PR DESCRIPTION
### Description

This PR just updates the `npm i` command in the `README`.
- switches to longhand `install`
- removes `-S` (short for `--save`) which has been the default for a long time and is no longer necessary
- adds `--save-dev` (because the vast majority of the time, pact is used as dev-time, not as a production dependency)
- removes `@latest` which is redundant and unnecessary

```diff
-npm i -S @pact-foundation/pact@latest
+npm install --save-dev @pact-foundation/pact
```