### PR TITLE
docs: fix provider stateHandlers example

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -120,9 +120,9 @@ If you have defined any `state`s in your consumer tests, the `Verifier` can put 
 const opts = {
   ...
   stateHandlers: {
-    [null]: () => {
+    "null": () => {
       // This is the "default" state handler, when no state is given
-    }
+    },
     "Has no animals": () => {
       animalRepository.clear()
       return Promise.resolve(`Animals removed from the db`)


### PR DESCRIPTION
## What does this PR do?

This PR makes a couple small changes to the [Provider Verification docs](https://docs.pact.io/implementation_guides/javascript/docs/provider#api-with-provider-states) – specifically the *API with Provider States* `stateHandlers` example code

This fixes two issues:
1) there was a missing comma, so the example was technically broken
2) `[null]:` as a property key doesn't work in TypeScript. This updates it to work in JS *and* TS

```diff
 const opts = {
   ...
   stateHandlers: {
-    [null]: () => {
+    "null": () => {
       // This is the "default" state handler, when no state is given
-    }
+    },
     "Has no animals": () => {
       animalRepository.clear()
       return Promise.resolve(`Animals removed from the db`)
```

## More on `[null]`

When this code is used with TS, it raises the following error:
> `A computed property name must be of type 'string', 'number', 'symbol', or 'any'`

TS is more strict than JS here, which allows it, but I'm pretty sure `[null]` is just coerced into `"null"` at runtime with JS, so I put that in explicitly.

## Other notes

### Slack thread

I raised this in [the Pact Slack](https://pact-foundation.slack.com/archives/C9VBGLUM9/p1750801201014229) yesterday, but figured I'd go ahead and just cut a PR to get the ball rolling

### Next Steps(?)

#### misleading/wrong attribution of example

Just above this code example, it says "Here is an example from our [e2e suite](https://github.com/pact-foundation/pact-js/blob/master/examples/e2e/test/provider.spec.js):". But the `[null]` case is not actually part of that example, and looks like it was added later (although I couldn't easily follow the Git history with `blame`).

I think it'd be best to resolve this, to avoid any confusion. Perhaps just removing that line?

#### thoughts on a different approach to registering state handlers

I tend to think a `getStateHandler` function would  have been a better pattern than `stateHandlers` for this, b/c it'd allow stuff like switch statements, which handle default cases more elegantly

```
getStateHandler: (stateName: string) {
  switch (stateName) {
    case "Has no animals":
      return () => { ... },
    default:
      return () => { ... },
  }
}
```

Maybe there are compelling reasons to have it as it is with the static `stateHandlers` object though 🤷 