### PR TITLE
fix: use /{*splat} for express proxy routes to match root and wildcar…

### DIFF
--- a/src/dsl/verifier/proxy/messages.ts
+++ b/src/dsl/verifier/proxy/messages.ts
@@ -159,7 +159,7 @@ export const setupMessageProxyApplication = (
   });
 
   // Proxy server will respond to Verifier process
-  app.all('/{splat}', createProxyMessageHandler(config));
+  app.all('/{*splat}', createProxyMessageHandler(config));
 
   return app;
 };

--- a/src/dsl/verifier/proxy/proxy.ts
+++ b/src/dsl/verifier/proxy/proxy.ts
@@ -47,7 +47,7 @@ export const createProxy = (
     })
   );
   app.use(bodyParser.urlencoded({ extended: true }));
-  app.use('/*splat', bodyParser.raw({ type: '*/*' }));
+  app.use('/{*splat}', bodyParser.raw({ type: '*/*' }));
 
   // Hooks
   const hooksState: HooksState = {
@@ -83,13 +83,7 @@ export const createProxy = (
   app.post(messageTransportPath, createProxyMessageHandler(config));
 
   // Proxy server will respond to Verifier process
-  app.all('/*splat', (req, res) => {
-    logger.debug(`Proxying ${req.method}: ${req.path}`);
-
-    proxy.web(req, res, toServerOptions(config, req));
-  });
-
-  app.all('/', (req, res) => {
+  app.all('/{*splat}', (req, res) => {
     logger.debug(`Proxying ${req.method}: ${req.path}`);
 
     proxy.web(req, res, toServerOptions(config, req));

--- a/src/messageProviderPact.ts
+++ b/src/messageProviderPact.ts
@@ -155,7 +155,7 @@ export class MessageProviderPact {
     });
 
     // Proxy server will respond to Verifier process
-    app.all('/{splat}', this.setupVerificationHandler());
+    app.all('/{*splat}', this.setupVerificationHandler());
 
     return app;
   }


### PR DESCRIPTION
…d subpaths
 
 Follow on from #1582 / #1581


