### PR TITLE
fix: gracefully handle state handler errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
         "randexp": "^0.5.3",
-        "router": "^2.2.0"
+        "router": "^2.2.0",
+        "stack-utils": "^2.0.6"
       },
       "devDependencies": {
         "@babel/cli": "7.28.3",
@@ -40,6 +41,7 @@
         "@types/ramda": "0.31.1",
         "@types/sinon": "17.0.4",
         "@types/sinon-chai": "4.0.0",
+        "@types/stack-utils": "^2.0.3",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "chai": "6.2.0",
@@ -2720,6 +2722,12 @@
       "integrity": "sha512-mZuhZSycMmwYKeYo+f81aIEpEH5h/22lWKoQOPLnrwSpA6ECszsQq7gNesUSLCp1HklneObQ9C+/zqcXP0/7lQ==",
       "dev": true
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2998,6 +3006,13 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -3533,6 +3548,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ajv": {
@@ -4177,15 +4202,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cliui": {
@@ -6063,15 +6079,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -9454,13 +9461,13 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.9.5",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
@@ -10904,6 +10911,27 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -13872,6 +13900,11 @@
       "integrity": "sha512-mZuhZSycMmwYKeYo+f81aIEpEH5h/22lWKoQOPLnrwSpA6ECszsQq7gNesUSLCp1HklneObQ9C+/zqcXP0/7lQ==",
       "dev": true
     },
+    "@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -14146,6 +14179,12 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -14455,6 +14494,14 @@
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -14903,12 +14950,6 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
     },
     "cliui": {
       "version": "8.0.1",
@@ -16293,11 +16334,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
@@ -18712,12 +18748,12 @@
       "dev": true
     },
     "pino": {
-      "version": "9.9.5",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "requires": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
@@ -19766,6 +19802,21 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
+      }
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "lodash": "^4.17.21",
     "ramda": "^0.32.0",
     "randexp": "^0.5.3",
-    "router": "^2.2.0"
+    "router": "^2.2.0",
+    "stack-utils": "^2.0.6"
   },
   "devDependencies": {
     "@babel/cli": "7.28.3",
@@ -134,6 +135,7 @@
     "@types/ramda": "0.31.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
+    "@types/stack-utils": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "chai": "6.2.0",

--- a/src/dsl/verifier/proxy/stateHandler/stateHandler.spec.ts
+++ b/src/dsl/verifier/proxy/stateHandler/stateHandler.spec.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import express from 'express';
 
+import sinon from 'sinon';
 import { createProxyStateHandler } from './stateHandler';
 import { ProxyOptions, StateHandlers } from '../types';
 
@@ -54,7 +55,8 @@ describe('#createProxyStateHandler', () => {
       },
     };
 
-    it('returns a 500', async () => {
+    it('returns a 200 and logs an error', async () => {
+      const spy = sinon.spy(console, 'log');
       const h = createProxyStateHandler({
         stateHandlers: badStateHandlers,
       } as ProxyOptions);
@@ -65,7 +67,11 @@ describe('#createProxyStateHandler', () => {
         mockResponse as express.Response
       );
 
-      expect(res).to.eql(500);
+      expect(res).to.eql(200);
+      expect(spy.callCount).to.eql(3);
+      expect(spy.getCall(0).args[0]).to.include(
+        "Error executing state handler for state 'thing exists' on 'setup'."
+      );
     });
   });
 });

--- a/src/dsl/verifier/proxy/stateHandler/stateHandler.ts
+++ b/src/dsl/verifier/proxy/stateHandler/stateHandler.ts
@@ -1,14 +1,43 @@
 import express from 'express';
 
+import StackUtils from 'stack-utils';
+import chalk from 'chalk';
 import { ProxyOptions, ProviderState } from '../types';
 import { setupStates } from './setupStates';
 
+const cleanStack = (e: Error) => {
+  const stack = new StackUtils({
+    cwd: process.cwd(),
+    internals: StackUtils.nodeInternals(),
+  });
+
+  if (!e.stack) return '';
+  const cleanedStack = stack.clean(e.stack);
+  const lines = cleanedStack.split('\n').map((line) => line.trim());
+
+  return lines[0];
+};
+
 export const createProxyStateHandler =
   (config: ProxyOptions) =>
-  (req: express.Request, res: express.Response): Promise<express.Response> => {
-    const message: ProviderState = req.body;
+  async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<express.Response> => {
+    const state: ProviderState = req.body;
+    try {
+      const data = await setupStates(state, config);
+      return res.json(data);
+    } catch (e) {
+      const error = `\nError executing state handler for state '${state.state}' on '${state.action}'.`;
+      const errorDetails = `↳ Error details: ${e.message}`;
+      const errorSource = `↳ Error source: ${cleanStack(e)}\n`;
+      /* eslint-disable no-console */
+      console.log(chalk.red(error));
+      console.log(chalk.red(errorDetails));
+      console.log(chalk.red(errorSource));
+      /* eslint-enable */
 
-    return Promise.resolve(setupStates(message, config))
-      .then((data) => res.json(data))
-      .catch((e) => res.status(500).send(e));
+      return res.status(200).send();
+    }
   };


### PR DESCRIPTION
Previously, when an error was thrown in a state handler an HTTP 500 was sent back to the core engine, making it hard to debug the issue from within test frameworks.

This change wraps the state handlers with error
handling, rather than propagating the error back
to the pact core engine. Errors will be clearly printed to the console (and logged at ERROR level).

Fixes #631
