### PR TITLE
fix: replace deprecated macos 13 build with macos-15-intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
         os:
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Remove deprecated macos build - https://github.com/actions/runner-images/issues/13046 which is breaking for https://github.com/pact-foundation/pact-js/pull/1627
