### PR TITLE
fix: ability to validate both message and HTTP

### DIFF
--- a/src/dsl/verifier/verifier.ts
+++ b/src/dsl/verifier/verifier.ts
@@ -125,7 +125,7 @@ export class Verifier {
         providerStatesSetupUrl: `${this.address}:${port}${this.stateSetupPath}`,
         ...omit(this.config, 'handlers'),
         providerBaseUrl: `${this.address}:${port}`,
-        transports: this.config.transports?.concat([
+        transports: (this.config.transports || []).concat([
           {
             port,
             path: this.messageTransportPath,


### PR DESCRIPTION
The transports configuration was not being sent if no user-defined transports were provided. 

Fixes #1633