### PR TITLE
chore: allow script for pact-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,5 +161,10 @@
     "source-map-support": "0.5.21",
     "tsx": "4.21.0",
     "typescript": "5.9.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@pact-foundation/pact-core"
+    ]
   }
 }


### PR DESCRIPTION
Node package managers like `pnpm` and `aube` disable install scripts by default as a security measure. The `pact-core` dependency should be excepted in our case.
