### PR TITLE
fix: extract content type from matchers

### DIFF
--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -9,6 +9,7 @@ import path = require('path');
 
 // eslint-disable-next-line import/first
 import { PactV4 } from './v4';
+import { MatchersV3 } from './v3';
 
 const { expect } = chai;
 
@@ -157,6 +158,55 @@ describe('V4 Pact', () => {
         'http metadata test name'
       );
     });
+
+    it('supports regex matcher for response content-type with optional charset', () =>
+      pact
+        .addInteraction()
+        .uponReceiving('a response with regex content-type header matcher')
+        .withRequest('GET', '/')
+        .willRespondWith(200, (builder) => {
+          builder
+            .headers({
+              'Content-Type': MatchersV3.regex(
+                /^application\/json(;\s?charset=[\w-]+)?$/i,
+                'application/json'
+              ),
+            })
+            .jsonBody({
+              foo: 'bar',
+            });
+        })
+        .executeTest(async (server) => {
+          const response = await axios.get(server.url);
+          expect(response.data).to.deep.equal({ foo: 'bar' });
+        }));
+
+    it('supports regex matcher for request content-type with optional charset', () =>
+      pact
+        .addInteraction()
+        .uponReceiving('a request with regex content-type header matcher')
+        .withRequest('POST', '/', (builder) => {
+          builder
+            .headers({
+              'Content-Type': MatchersV3.regex(
+                /^application\/json(;\s?charset=[\w-]+)?$/i,
+                'application/json'
+              ),
+            })
+            .jsonBody({
+              foo: 'bar',
+            });
+        })
+        .willRespondWith(200, (builder) => {
+          builder.jsonBody({
+            ok: true,
+          });
+        })
+        .executeTest((server) =>
+          axios.post(server.url, {
+            foo: 'bar',
+          })
+        ));
   });
 
   describe('Asynchronous message contract', () => {

--- a/src/v3/ffi.spec.ts
+++ b/src/v3/ffi.spec.ts
@@ -1,0 +1,22 @@
+import * as chai from 'chai';
+import { contentTypeFromHeaders } from './ffi';
+import { regex } from './matchers';
+
+const { expect } = chai;
+
+describe('V3 Pact FFI', () => {
+  describe('#contentTypeFromHeaders', () => {
+    it('uses matcher example value when content-type header is a matcher', () => {
+      const headers = {
+        'Content-Type': regex(
+          /^application\/json(;\s?charset=[\w-]+)?$/i,
+          'application/json'
+        ),
+      };
+
+      expect(contentTypeFromHeaders(headers, 'application/json')).to.eq(
+        'application/json'
+      );
+    });
+  });
+});

--- a/src/v3/ffi.ts
+++ b/src/v3/ffi.ts
@@ -1,6 +1,6 @@
 import { forEachObjIndexed } from 'ramda';
-import { ConsumerInteraction } from '@pact-foundation/pact-core';
-import { Matcher, TemplateHeaders, V3Request, V3Response } from './types';
+import type { ConsumerInteraction } from '@pact-foundation/pact-core';
+import type { Matcher, TemplateHeaders, V3Request, V3Response } from './types';
 import * as MatchersV3 from './matchers';
 
 type TemplateHeaderArrayValue = string[] | Matcher<string>[];
@@ -59,7 +59,6 @@ export const setResponseDetails = (
   }, res.headers);
 };
 
-// TODO: this might need to consider an array of values
 export const contentTypeFromHeaders = (
   headers: TemplateHeaders | undefined,
   defaultContentType: string
@@ -67,7 +66,10 @@ export const contentTypeFromHeaders = (
   let contentType: string | Matcher<string> = defaultContentType;
   forEachObjIndexed((v, k) => {
     if (`${k}`.toLowerCase() === 'content-type') {
-      contentType = MatchersV3.matcherValueOrString(v);
+      const headerValue = Array.isArray(v) ? v[0] : v;
+      contentType = MatchersV3.isMatcher(headerValue)
+        ? MatchersV3.matcherValueOrString(headerValue.value)
+        : MatchersV3.matcherValueOrString(headerValue);
     }
   }, headers || {});
 


### PR DESCRIPTION
Fixes failures when consumers use regex matchers for JSON Content-Type headers with optional charset parameters.

Adds regression coverage for the v3 bug and confirms the same scenario already works in v4.

Ref: PACT-6546