### PR TITLE
chore: remove non-overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,18 +11,3 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
-
-# Matches multiple files with brace expansion notation
-# Set default charset
-[*.{js}]
-charset = utf-8
-
-# Indentation override for all JS under lib directory
-[**/*.js]
-indent_style = space
-indent_size = 2
-
-# Matches the exact files either package.json or .travis.yml
-[{package.json,.travis.yml}]
-indent_style = space
-indent_size = 2


### PR DESCRIPTION
The default is always to indent with 2 spaces and use utf-8, so the overrides are just re-stating the default.
