### PR TITLE
feat: add the addInteractionReference function to V4 DSL classes to support external references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "16.3.1",
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.1.0",
+        "@pact-foundation/pact-core": "^19.2.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
         "chalk": "4.1.2",
@@ -1675,9 +1675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1695,9 +1692,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1715,9 +1709,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1735,9 +1726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2558,9 +2546,9 @@
       "license": "MIT"
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-19.1.0.tgz",
-      "integrity": "sha512-2jyns+jkgLZK79ovM3aMSYHaMyu6dWmwOQjykj0GUhs37G5jXPffSsmBR1fm//KSf244OvuyELrAsWC+FnUHgg==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-19.2.0.tgz",
+      "integrity": "sha512-7EB2e850hmBzGnwOYTRj4TCFCJQa9zaOy53bK+ybzEDx801olf0gVlYqMYHt1EsHUZzmtS5uDybpr9UMcZQxgg==",
       "cpu": [
         "x64",
         "ia32",
@@ -2584,19 +2572,19 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@pact-foundation/pact-core-darwin-arm64": "19.1.0",
-        "@pact-foundation/pact-core-darwin-x64": "19.1.0",
-        "@pact-foundation/pact-core-linux-arm64-glibc": "19.1.0",
-        "@pact-foundation/pact-core-linux-arm64-musl": "19.1.0",
-        "@pact-foundation/pact-core-linux-x64-glibc": "19.1.0",
-        "@pact-foundation/pact-core-linux-x64-musl": "19.1.0",
-        "@pact-foundation/pact-core-windows-x64": "19.1.0"
+        "@pact-foundation/pact-core-darwin-arm64": "19.2.0",
+        "@pact-foundation/pact-core-darwin-x64": "19.2.0",
+        "@pact-foundation/pact-core-linux-arm64-glibc": "19.2.0",
+        "@pact-foundation/pact-core-linux-arm64-musl": "19.2.0",
+        "@pact-foundation/pact-core-linux-x64-glibc": "19.2.0",
+        "@pact-foundation/pact-core-linux-x64-musl": "19.2.0",
+        "@pact-foundation/pact-core-windows-x64": "19.2.0"
       }
     },
     "node_modules/@pact-foundation/pact-core-darwin-arm64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-19.1.0.tgz",
-      "integrity": "sha512-bizRo7SawD6B3844QCR2Hap8Eh5qrrBSTZcRN6yLabD5KhIaIXWSXM/WaynT+f91Q9Up3GNF793/Vl3dxPf+3g==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-19.2.0.tgz",
+      "integrity": "sha512-cQvvWfJKS7iMzkunzh/kdgmyVLhAxyr/BQ8fOnMco2M/1+GHR+sOXvhrR1tes+NAYd1xjE3fbg1K2Flno8aDBw==",
       "cpu": [
         "arm64"
       ],
@@ -2607,9 +2595,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-darwin-x64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-19.1.0.tgz",
-      "integrity": "sha512-au8ldd9XhRji1QNW/1Z/KVW4lfIFjrLwkDTbtJmliM83yNhvV+a3nhrOJcx11hmhnlGIT7otGLb9a5k1APWAMw==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-19.2.0.tgz",
+      "integrity": "sha512-UltPXDZ+h1r3JqgIpEBP16bQzB90otd1QbcoeM3XakF9khCrYhW4y9llSuaosyqPFYwCk+mLaZTl/4iitJJaow==",
       "cpu": [
         "x64"
       ],
@@ -2620,14 +2608,11 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-glibc": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-19.1.0.tgz",
-      "integrity": "sha512-1TBHpF8rOnukFUtTYyf7ULTT24FnYQlkSWYd+mN73uhrFX/irpxMgyJFAXBOoeI5VZTlSk1XuPy5WBK6SeMcEA==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-19.2.0.tgz",
+      "integrity": "sha512-amiv4COurH1FRa7DSH3ks4UPQCb5J3x4GKrArf8UsTOkNhVGFUWVl83LOELj9Gtk67GwJ96iF7/fQps8I/iFIA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2636,14 +2621,11 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-musl": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-19.1.0.tgz",
-      "integrity": "sha512-CvMbzjrCsxicVEd/yJ2vjiMTUsjFpgoC4lr8qL2lajLNEywDcumC9d+CtRbboauG8XqGRqxvH6tTrhO5nzZUPg==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-19.2.0.tgz",
+      "integrity": "sha512-tGWF7dP72Ho1A1PApyUqUMRI/e+gfbPxfaXxwWMXNh8JLK2jQQnP4bWymGwHQ4vxL7wn8ayx8I5y6x1vk/2+rA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2652,14 +2634,11 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-glibc": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-19.1.0.tgz",
-      "integrity": "sha512-P+qwj65TpGRw+bn9//Eugpr98Hfab1zsOeCvj6SNIRr6VW3whCpojvESZXfISxuK+gP7KAXTbbG1gApbhwCQSA==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-19.2.0.tgz",
+      "integrity": "sha512-/ZNuWKuFJSBRZH09t7FXqKLy5koCaMIZ4RdbockLYlNo8uWF2ALfRCllj+SbXPLK+T+lVnBrs5s94X2cu4Rc7A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2668,14 +2647,11 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-musl": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-19.1.0.tgz",
-      "integrity": "sha512-SHYSGjznWj2rz3/ey6TqPdI9RezDVPkwszUF83Qc5iwuMRQgqcqgMEhjZaMS7mtGBX/tmLWqBgCHu/Z56EpBsQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-19.2.0.tgz",
+      "integrity": "sha512-n0m39CzVkq8J2alir1redm0rAdUVQzkKJqYBQdRmhEIa+QeGjUrJq+gmakUysoJxfSY4UthnJ9jS8SoyiZ+k6A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2684,9 +2660,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-windows-x64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-19.1.0.tgz",
-      "integrity": "sha512-PIwNMO38QDCfd/h3Ys8i+1M1Yx7l+jf+oL3oxIPE1jby4CgY/MY2hoOH3VwFSYQhaOPHj1n7TpcW9EpbIkGdSA==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-19.2.0.tgz",
+      "integrity": "sha512-WZSDBL1Sn8y5+YJTK+HDiS/Fn9th1M4QJW2dflQ8UFwoaIh6yb0TrJjtuWbDGIwNeD4Sv8CJ5jJOf1nyNjFLfg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-core": "^19.1.0",
+    "@pact-foundation/pact-core": "^19.2.0",
     "axios": "^1.12.2",
     "body-parser": "^2.2.0",
     "chalk": "4.1.2",

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -178,7 +178,7 @@ describe('V4 Pact', () => {
       await pact
         .addInteraction()
         .uponReceiving(description)
-        .addInteractionReference(
+        .reference(
           'Jira',
           'TICKET-123',
           'https://jira.example.com/TICKET-123',
@@ -281,7 +281,7 @@ describe('V4 Pact', () => {
 
       await pact
         .addAsynchronousInteraction()
-        .addInteractionReference(
+        .reference(
           'GitHub',
           'PR-456',
           'https://github.com/example/repo/pull/456',
@@ -341,7 +341,7 @@ describe('V4 Pact', () => {
 
       await pact
         .addSynchronousInteraction(description)
-        .addInteractionReference(
+        .reference(
           'Jira',
           'TICKET-789',
           'https://jira.example.com/TICKET-789',

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -56,6 +56,21 @@ describe('V4 Pact', () => {
     expect(comments.testname).to.equal(testName);
   };
 
+  const expectReferenceToEqual = (
+    interaction: Record<string, unknown>,
+    group: string,
+    name: string,
+    value: string,
+  ): void => {
+    const comments = interaction.comments as Record<string, unknown>;
+    const references = comments.references as Record<
+      string,
+      Record<string, string>
+    >;
+
+    expect(references[group][name]).to.equal(value);
+  };
+
   beforeEach(() => {
     pact = new PactV4({
       consumer: 'v4consumer',
@@ -157,6 +172,31 @@ describe('V4 Pact', () => {
       );
     });
 
+    it('records interaction references in the pact file', async () => {
+      const description = 'v4 http interaction with references';
+
+      await pact
+        .addInteraction()
+        .uponReceiving(description)
+        .addInteractionReference(
+          'Jira',
+          'TICKET-123',
+          'https://jira.example.com/TICKET-123',
+        )
+        .withRequest('GET', '/')
+        .willRespondWith(200)
+        .executeTest(async (server) => axios.get(server.url));
+
+      const interaction = interactionByDescription(description);
+
+      expectReferenceToEqual(
+        interaction,
+        'Jira',
+        'TICKET-123',
+        'https://jira.example.com/TICKET-123',
+      );
+    });
+
     it('supports regex matcher for response content-type with optional charset', () =>
       pact
         .addInteraction()
@@ -235,6 +275,31 @@ describe('V4 Pact', () => {
         'async metadata test name',
       );
     });
+
+    it('records interaction references in the pact file', async () => {
+      const description = 'v4 async interaction with references';
+
+      await pact
+        .addAsynchronousInteraction()
+        .addInteractionReference(
+          'GitHub',
+          'PR-456',
+          'https://github.com/example/repo/pull/456',
+        )
+        .expectsToReceive(description, (builder) => {
+          builder.withJSONContent({ event: 'user.created' });
+        })
+        .executeTest(async () => Promise.resolve());
+
+      const interaction = interactionByDescription(description);
+
+      expectReferenceToEqual(
+        interaction,
+        'GitHub',
+        'PR-456',
+        'https://github.com/example/repo/pull/456',
+      );
+    });
   });
 
   describe('Synchronous message contract', () => {
@@ -268,6 +333,34 @@ describe('V4 Pact', () => {
         'covered by sync metadata test',
         'second note from sync metadata test',
         'sync metadata test name',
+      );
+    });
+
+    it('records interaction references in the pact file', async () => {
+      const description = 'v4 sync interaction with references';
+
+      await pact
+        .addSynchronousInteraction(description)
+        .addInteractionReference(
+          'Jira',
+          'TICKET-789',
+          'https://jira.example.com/TICKET-789',
+        )
+        .withRequest((builder) => {
+          builder.withJSONContent({ request: 'ping' });
+        })
+        .withResponse((builder) => {
+          builder.withJSONContent({ response: 'pong' });
+        })
+        .executeTest(async () => Promise.resolve());
+
+      const interaction = interactionByDescription(description);
+
+      expectReferenceToEqual(
+        interaction,
+        'Jira',
+        'TICKET-789',
+        'https://jira.example.com/TICKET-789',
       );
     });
   });

--- a/src/pact.integration.spec.ts
+++ b/src/pact.integration.spec.ts
@@ -178,11 +178,7 @@ describe('V4 Pact', () => {
       await pact
         .addInteraction()
         .uponReceiving(description)
-        .reference(
-          'Jira',
-          'TICKET-123',
-          'https://jira.example.com/TICKET-123',
-        )
+        .reference('Jira', 'TICKET-123', 'https://jira.example.com/TICKET-123')
         .withRequest('GET', '/')
         .willRespondWith(200)
         .executeTest(async (server) => axios.get(server.url));
@@ -341,11 +337,7 @@ describe('V4 Pact', () => {
 
       await pact
         .addSynchronousInteraction(description)
-        .reference(
-          'Jira',
-          'TICKET-789',
-          'https://jira.example.com/TICKET-789',
-        )
+        .reference('Jira', 'TICKET-789', 'https://jira.example.com/TICKET-789')
         .withRequest((builder) => {
           builder.withJSONContent({ request: 'ping' });
         })

--- a/src/v4/http/types.ts
+++ b/src/v4/http/types.ts
@@ -68,7 +68,7 @@ export interface V4UnconfiguredInteraction {
   pending(pending?: boolean): V4UnconfiguredInteraction;
   comment(comment: Comment | CustomComment): V4UnconfiguredInteraction;
   testName(name: string): V4UnconfiguredInteraction;
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,

--- a/src/v4/http/types.ts
+++ b/src/v4/http/types.ts
@@ -68,6 +68,11 @@ export interface V4UnconfiguredInteraction {
   pending(pending?: boolean): V4UnconfiguredInteraction;
   comment(comment: Comment | CustomComment): V4UnconfiguredInteraction;
   testName(name: string): V4UnconfiguredInteraction;
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredInteraction;
   withCompleteRequest(request: V4Request): V4InteractionWithCompleteRequest;
   withRequest(
     method: string,

--- a/src/v4/http/unconfiguredInteraction.ts
+++ b/src/v4/http/unconfiguredInteraction.ts
@@ -69,6 +69,16 @@ export class UnconfiguredInteraction implements V4UnconfiguredInteraction {
     return this;
   }
 
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredInteraction {
+    this.interaction.addInteractionReference(group, name, value);
+
+    return this;
+  }
+
   withCompleteRequest(_request: V4Request): V4InteractionWithCompleteRequest {
     throw new Error('withCompleteRequest is not implemented');
   }

--- a/src/v4/http/unconfiguredInteraction.ts
+++ b/src/v4/http/unconfiguredInteraction.ts
@@ -69,7 +69,7 @@ export class UnconfiguredInteraction implements V4UnconfiguredInteraction {
     return this;
   }
 
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,

--- a/src/v4/message/asynchronousMessage.ts
+++ b/src/v4/message/asynchronousMessage.ts
@@ -127,6 +127,16 @@ export class UnconfiguredAsynchronousMessage
     return this;
   }
 
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredAsynchronousMessage {
+    this.message.interaction.addInteractionReference(group, name, value);
+
+    return this;
+  }
+
   usingPlugin(config: PluginConfig): V4AsynchronousMessageWithPlugin {
     this.pact.addPlugin(config.plugin, config.version);
 

--- a/src/v4/message/asynchronousMessage.ts
+++ b/src/v4/message/asynchronousMessage.ts
@@ -127,7 +127,7 @@ export class UnconfiguredAsynchronousMessage
     return this;
   }
 
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,

--- a/src/v4/message/index.ts
+++ b/src/v4/message/index.ts
@@ -78,7 +78,7 @@ export class UnconfiguredSynchronousMessage
     return this;
   }
 
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,

--- a/src/v4/message/index.ts
+++ b/src/v4/message/index.ts
@@ -78,6 +78,16 @@ export class UnconfiguredSynchronousMessage
     return this;
   }
 
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredSynchronousMessage {
+    this.interaction.addInteractionReference(group, name, value);
+
+    return this;
+  }
+
   usingPlugin(config: PluginConfig): V4SynchronousMessageWithPlugin {
     this.pact.addPlugin(config.plugin, config.version);
 

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -58,6 +58,11 @@ export interface V4UnconfiguredSynchronousMessage {
   pending(pending?: boolean): V4UnconfiguredSynchronousMessage;
   comment(comment: Comment | CustomComment): V4UnconfiguredSynchronousMessage;
   testName(name: string): V4UnconfiguredSynchronousMessage;
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredSynchronousMessage;
   usingPlugin(config: PluginConfig): V4SynchronousMessageWithPlugin;
   withRequest(r: V4MessageRequestBuilderFunc): V4SynchronousMessageWithRequest;
 }
@@ -129,6 +134,11 @@ export interface V4UnconfiguredAsynchronousMessage {
   pending(pending?: boolean): V4UnconfiguredAsynchronousMessage;
   comment(comment: Comment | CustomComment): V4UnconfiguredAsynchronousMessage;
   testName(name: string): V4UnconfiguredAsynchronousMessage;
+  addInteractionReference(
+    group: string,
+    name: string,
+    value: string,
+  ): V4UnconfiguredAsynchronousMessage;
   usingPlugin(config: PluginConfig): V4AsynchronousMessageWithPlugin;
   expectsToReceive(
     description: string,

--- a/src/v4/message/types.ts
+++ b/src/v4/message/types.ts
@@ -58,7 +58,7 @@ export interface V4UnconfiguredSynchronousMessage {
   pending(pending?: boolean): V4UnconfiguredSynchronousMessage;
   comment(comment: Comment | CustomComment): V4UnconfiguredSynchronousMessage;
   testName(name: string): V4UnconfiguredSynchronousMessage;
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,
@@ -134,7 +134,7 @@ export interface V4UnconfiguredAsynchronousMessage {
   pending(pending?: boolean): V4UnconfiguredAsynchronousMessage;
   comment(comment: Comment | CustomComment): V4UnconfiguredAsynchronousMessage;
   testName(name: string): V4UnconfiguredAsynchronousMessage;
-  addInteractionReference(
+  reference(
     group: string,
     name: string,
     value: string,


### PR DESCRIPTION
New method `addInteractionReference(group, name, value)` added to the V4 unconfigured interaction stage for all three interaction types:                         

|                  File                  |                                             Change                                              |
|----------------------------------|-------------------------------------------------------------------------------------|
| src/v4/http/types.ts                   | Added addInteractionReference to V4UnconfiguredInteraction interface                            |
| src/v4/http/unconfiguredInteraction.ts | Implemented in UnconfiguredInteraction class | 
| src/v4/message/types.ts                | Added to both V4UnconfiguredSynchronousMessage and V4UnconfiguredAsynchronousMessage interfaces |
| src/v4/message/index.ts                | Implemented in UnconfiguredSynchronousMessage                              |
| src/v4/message/asynchronousMessage.ts  | Implemented in UnconfiguredAsynchronousMessage |
| src/pact.integration.spec.ts           | Added 3 integration tests (HTTP, async, sync)                                                   |
 
 This PR is in Draft status as it requires the latest FFI changes in pact-js-core to be released.