### PR TITLE
fix(types): allow narrow body type in {synchronous,asynchronous}BodyHandler

### DIFF
--- a/src/messageConsumerPact.ts
+++ b/src/messageConsumerPact.ts
@@ -227,12 +227,19 @@ export class MessageConsumerPact {
 // TODO: create more basic adapters for API handlers
 
 // bodyHandler takes a synchronous function and returns
-// a wrapped function that accepts a Message and returns a Promise
-export function synchronousBodyHandler<R>(
-  handler: (body: AnyJson | Buffer) => R,
-): MessageConsumer {
+// a wrapped function that accepts a Message and returns a Promise.
+//
+// The body type defaults to `AnyJson | Buffer` (the runtime type of
+// `m.contents`), but callers may narrow it to a custom shape (e.g. an
+// interface describing the JSON they expect to receive) by supplying the
+// `B` type parameter. The narrowing is a TypeScript-only assertion; the
+// runtime value is still whatever the producer sent.
+export function synchronousBodyHandler<
+  R,
+  B extends AnyJson | Buffer = AnyJson | Buffer,
+>(handler: (body: B) => R): MessageConsumer {
   return (m: ConcreteMessage): Promise<R> => {
-    const body = m.contents;
+    const body = m.contents as B;
 
     return new Promise((resolve, reject) => {
       try {
@@ -246,10 +253,12 @@ export function synchronousBodyHandler<R>(
 }
 
 // bodyHandler takes an asynchronous (promisified) function and returns
-// a wrapped function that accepts a Message and returns a Promise
+// a wrapped function that accepts a Message and returns a Promise.
+// See `synchronousBodyHandler` for the rationale behind the `B` parameter.
 // TODO: move this into its own package and re-export?
-export function asynchronousBodyHandler<R>(
-  handler: (body: AnyJson | Buffer) => Promise<R>,
-): MessageConsumer {
-  return (m: ConcreteMessage) => handler(m.contents);
+export function asynchronousBodyHandler<
+  R,
+  B extends AnyJson | Buffer = AnyJson | Buffer,
+>(handler: (body: B) => Promise<R>): MessageConsumer {
+  return (m: ConcreteMessage) => handler(m.contents as B);
 }


### PR DESCRIPTION
The `synchronousBodyHandler` / `asynchronousBodyHandler` helpers expose `handler: (body: AnyJson | Buffer) => R` in their signatures, so users who want to narrow the body to a domain-specific shape (the consumer side of the contract already knows what JSON to expect) hit a contravariance error:

```ts
type CustomType = { type: 'custom' };
const myHandler = (body: CustomType) => { /* ... */ };
synchronousBodyHandler(myHandler); // TS2345
```

The pre-existing workaround in [jest-pact](https://github.com/pact-foundation/jest-pact/blob/0e9b512fc4d508fe0c87dcf700a60efb202df1aa/src/test/messagePactWith.test.ts#L41) is `(dogApiHandler as unknown) as (body: AnyJson | Buffer) => void`, which the reporter rightly notes "doesn't sound great." This PR adds an optional generic so callers can opt into the narrower type at the call site without `unknown` ladders.

## Change

In `src/messageConsumerPact.ts`:

```ts
export function synchronousBodyHandler<
  R,
  B extends AnyJson | Buffer = AnyJson | Buffer,
>(handler: (body: B) => R): MessageConsumer { ... }

export function asynchronousBodyHandler<
  R,
  B extends AnyJson | Buffer = AnyJson | Buffer,
>(handler: (body: B) => Promise<R>): MessageConsumer { ... }
```

- `B` defaults to `AnyJson | Buffer`, so existing callers compile unchanged - it's a purely additive type-level change.
- Inside the wrappers, `m.contents` is cast to `B` before the user's handler runs. This is a TypeScript-only assertion; the runtime value is unchanged (still whatever the producer sent).
- `B extends AnyJson | Buffer` keeps callers honest - you can narrow inside the union, but you can't pass a handler that expects `Map<string, unknown>` or some other unrelated shape.

## Verification

- `npm test` (vitest): 27 files, 268 tests, all passing.
- `tsc --noEmit`: clean.
- `biome lint`: clean.
- Existing callers in the repo (`src/v4/message/index.ts`, the spec files, the regression suite) all type-check unchanged with the default `B = AnyJson | Buffer`.

Closes #919
