### PR TITLE
feat: enable scarf download analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,25 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 </a>
 <br />
 
+## Anonymized analytics
+
+Pact JS uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
+
+For more information, see [docs.pact.io/telemetry](https://docs.pact.io/telemetry).
+
 [spec]: https://github.com/pact-foundation/pact-specification
 [10xx]: https://github.com/pact-foundation/pact-js/tree/10.x.x
 [9xx]: https://github.com/pact-foundation/pact-js/tree/9.x.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@pact-foundation/pact-core": "^19.2.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
         "chalk": "4.1.2",
@@ -4149,6 +4150,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "dependencies": {
     "@pact-foundation/pact-core": "^19.2.0",
+    "@scarf/scarf": "^1.4.0",
     "axios": "^1.12.2",
     "body-parser": "^2.2.0",
     "chalk": "4.1.2",


### PR DESCRIPTION
Replaces the previously defunct GA tracking with basic Scarf analytics. 

See https://docs.pact.io/telemetry for more.