### PR TITLE
fix(verifier): run beforeEach/afterEach once per interaction without desyncing on hook failure

### DIFF
--- a/src/dsl/verifier/proxy/hooks.spec.ts
+++ b/src/dsl/verifier/proxy/hooks.spec.ts
@@ -1,127 +1,118 @@
 import type { RequestHandler } from 'express';
 import { vi } from 'vitest';
 
-import {
-  type HooksState,
-  registerAfterHook,
-  registerBeforeHook,
-  registerHookStateTracking,
-} from './hooks';
+import { createHooksState, registerHooks } from './hooks';
 
-// This mimics the proxy setup (src/dsl/verifier/proxy/proxy.ts), whereby the
-// state handling middleware is run regardless of whether a hook is registered
-// or not.
-const doRequest = async (
-  action: string,
-  hooksState: HooksState,
-  hookHandler?: RequestHandler,
-) => {
-  const hooksStateHandler = registerHookStateTracking(hooksState);
-  const hookRequestHandler = hookHandler || ((_req, _res, next) => next());
+// Mimics the proxy: a single hooks middleware handles every `/_pactSetup`
+// request. `doRequest` drives it with a given action and resolves once the
+// middleware calls next().
+const doRequest = (action: string, handler: RequestHandler) => {
+  // biome-ignore lint/suspicious/noExplicitAny: partial mock — only body is needed
+  const request: any = { body: { action } };
 
-  // biome-ignore lint/suspicious/noExplicitAny: partial mock object — only body is needed to exercise the hook logic
-  const request: any = {
-    body: {
-      action,
-    },
-  };
-
-  return new Promise((resolve) => {
-    // biome-ignore lint/suspicious/noExplicitAny: null passed as res/next mocks; only body is exercised
-    hooksStateHandler(request, null as any, () => {
-      // biome-ignore lint/suspicious/noExplicitAny: null passed as res mock; only body is exercised
-      hookRequestHandler(request, null as any, resolve);
-    });
+  return new Promise<void>((resolve) => {
+    // biome-ignore lint/suspicious/noExplicitAny: null res mock; only body is exercised
+    handler(request, null as any, () => resolve());
   });
 };
 
-describe('Verifier', () => {
+describe('Verifier hooks', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe('#registerBeforeHook', () => {
-    describe('when the state setup routine is called multiple times before the next teardown', () => {
-      it('it executes the beforeEach hook only once', async () => {
-        const hooksState: HooksState = { setupCounter: 0 };
-        const hook = vi.fn().mockResolvedValue(undefined);
-        const hookHandler = registerBeforeHook(hook, hooksState);
+  it('runs beforeEach and afterEach once per interaction (multiple "given" states)', async () => {
+    const state = createHooksState();
+    const beforeEach = vi.fn().mockResolvedValue(undefined);
+    const afterEach = vi.fn().mockResolvedValue(undefined);
+    const handler = registerHooks({ beforeEach, afterEach }, state);
 
-        await doRequest('setup', hooksState, hookHandler);
-        await doRequest('setup', hooksState, hookHandler);
-        await doRequest('teardown', hooksState);
-        await doRequest('teardown', hooksState);
+    // Interaction with two "given" states: setup x2, teardown x2
+    await doRequest('setup', handler);
+    await doRequest('setup', handler);
+    await doRequest('teardown', handler);
+    await doRequest('teardown', handler);
 
-        expect(hook).toHaveBeenCalledOnce();
-      });
-    });
+    expect(beforeEach).toHaveBeenCalledOnce();
+    expect(afterEach).toHaveBeenCalledOnce();
   });
 
-  describe('#registerAfterHook', () => {
-    describe('when the state teardown routine is called multiple times before the next setup', () => {
-      it('it executes the afterEach hook only once', async () => {
-        const hooksState: HooksState = { setupCounter: 0 };
-        const hook = vi.fn().mockResolvedValue(undefined);
-        const hookHandler = registerAfterHook(hook, hooksState);
+  it('runs the hooks once for each of several interactions', async () => {
+    const state = createHooksState();
+    const beforeEach = vi.fn().mockResolvedValue(undefined);
+    const afterEach = vi.fn().mockResolvedValue(undefined);
+    const handler = registerHooks({ beforeEach, afterEach }, state);
 
-        await doRequest('setup', hooksState);
-        await doRequest('setup', hooksState);
-        await doRequest('teardown', hooksState, hookHandler);
-        await doRequest('teardown', hooksState, hookHandler);
+    // Interaction 1 (two states)
+    await doRequest('setup', handler);
+    await doRequest('setup', handler);
+    await doRequest('teardown', handler);
+    await doRequest('teardown', handler);
+    // Interaction 2 (one state)
+    await doRequest('setup', handler);
+    await doRequest('teardown', handler);
+    // Interaction 3 (three states)
+    await doRequest('setup', handler);
+    await doRequest('setup', handler);
+    await doRequest('setup', handler);
+    await doRequest('teardown', handler);
+    await doRequest('teardown', handler);
+    await doRequest('teardown', handler);
 
-        expect(hook).toHaveBeenCalledOnce();
-      });
-    });
+    expect(beforeEach).toHaveBeenCalledTimes(3);
+    expect(afterEach).toHaveBeenCalledTimes(3);
   });
 
-  describe('#registerBeforeHook and #registerAfterHook', () => {
-    describe('when the state teardown routine is called multiple times before the next setup', () => {
-      it('it executes the beforeEach and afterEach hooks only once', async () => {
-        const hooksState: HooksState = { setupCounter: 0 };
-        const beforeHook = vi.fn().mockResolvedValue(undefined);
-        const afterHook = vi.fn().mockResolvedValue(undefined);
-        const beforeHookHandler = registerBeforeHook(beforeHook, hooksState);
-        const afterHookHandler = registerAfterHook(afterHook, hooksState);
+  // Regression for #1864: a failing beforeEach used to desync a global counter,
+  // silently disabling the hooks for every subsequent interaction.
+  it('keeps running hooks for later interactions after a hook throws, and records the error', async () => {
+    const state = createHooksState();
+    const beforeEach = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transient failure'))
+      .mockResolvedValue(undefined);
+    const afterEach = vi.fn().mockResolvedValue(undefined);
+    const handler = registerHooks({ beforeEach, afterEach }, state);
 
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
+    // Three single-state interactions; beforeEach throws on the first.
+    for (let i = 0; i < 3; i++) {
+      await doRequest('setup', handler);
+      await doRequest('teardown', handler);
+    }
 
-        expect(beforeHook).toHaveBeenCalledOnce();
-        expect(afterHook).toHaveBeenCalledOnce();
-      });
-    });
+    expect(beforeEach).toHaveBeenCalledTimes(3);
+    expect(afterEach).toHaveBeenCalledTimes(3);
+    expect(state.errors).toHaveLength(1);
+    expect(state.errors[0].message).toContain('beforeEach');
+  });
 
-    describe('when multiple interactions are executed', () => {
-      it('it executes the beforeEach and afterEach hooks once for each interaction', async () => {
-        const hooksState: HooksState = { setupCounter: 0 };
-        const beforeHook = vi.fn().mockResolvedValue(undefined);
-        const afterHook = vi.fn().mockResolvedValue(undefined);
-        const beforeHookHandler = registerBeforeHook(beforeHook, hooksState);
-        const afterHookHandler = registerAfterHook(afterHook, hooksState);
+  // A throwing hook must never turn into a non-2xx response (the proxy must keep
+  // serving), or the core would retry the request and desync tracking.
+  it('still calls next() when a hook throws', async () => {
+    const state = createHooksState();
+    const beforeEach = vi.fn().mockRejectedValue(new Error('boom'));
+    const handler = registerHooks({ beforeEach }, state);
 
-        // Interaction 1 (two "given" states)
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
+    // doRequest resolves only when next() is called.
+    await expect(doRequest('setup', handler)).resolves.toBeUndefined();
+  });
 
-        // Interaction 2 (one "given" state)
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
+  // The core retries a failed state-change request: a duplicate "setup" before
+  // any "teardown" must not re-fire beforeEach nor desync the interaction state.
+  it('is idempotent under a retried setup request', async () => {
+    const state = createHooksState();
+    const beforeEach = vi.fn().mockResolvedValue(undefined);
+    const afterEach = vi.fn().mockResolvedValue(undefined);
+    const handler = registerHooks({ beforeEach, afterEach }, state);
 
-        // Interaction 3 (three "given" states)
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('setup', hooksState, beforeHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
-        await doRequest('teardown', hooksState, afterHookHandler);
+    await doRequest('setup', handler);
+    await doRequest('setup', handler); // retried/duplicate setup
+    await doRequest('teardown', handler);
+    // next interaction
+    await doRequest('setup', handler);
+    await doRequest('teardown', handler);
 
-        expect(beforeHook).toHaveBeenCalledTimes(3);
-        expect(afterHook).toHaveBeenCalledTimes(3);
-      });
-    });
+    expect(beforeEach).toHaveBeenCalledTimes(2);
+    expect(afterEach).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/dsl/verifier/proxy/hooks.ts
+++ b/src/dsl/verifier/proxy/hooks.ts
@@ -1,8 +1,20 @@
 /**
- * These handlers assume that the number of "setup" and "teardown" requests to
- * `/_pactSetup` are always sequential and balanced, i.e. if 3 "setup" actions
- * are received prior to an interaction being executed, then 3 "teardown"
- * actions will be received after that interaction has ended.
+ * `beforeEach`/`afterEach` are driven off the provider-state setup/teardown
+ * requests the core makes to `/_pactSetup`. For each interaction the core sends
+ * one or more "setup" actions, runs the interaction, then sends one or more
+ * "teardown" actions.
+ *
+ * We track the interaction boundary with a single `insideInteraction` flag that
+ * flips on the setup<->teardown edges, rather than counting requests. This is:
+ *   - idempotent under retries: the core retries a failed state-change request,
+ *     and a duplicate "setup" while already inside an interaction is a no-op; and
+ *   - self-healing: it cannot accumulate error and latch into a broken state.
+ *
+ * Hook failures are recorded on `HooksState.errors` and the state-change request
+ * is still answered with a success, so a throwing hook never turns into a non-2xx
+ * response (which the core would retry, desyncing interaction tracking). The
+ * verifier surfaces any recorded errors once verification completes, so a failing
+ * hook still fails the build.
  */
 import type { RequestHandler } from 'express';
 
@@ -10,56 +22,55 @@ import logger from '../../../common/logger';
 import type { Hook } from './types';
 
 export type HooksState = {
-  setupCounter: number;
+  insideInteraction: boolean;
+  errors: Error[];
 };
 
-export const registerHookStateTracking =
-  (hooksState: HooksState): RequestHandler =>
-  async ({ body }, _res, next) => {
-    if (body?.action === 'setup') hooksState.setupCounter += 1;
-    if (body?.action === 'teardown') hooksState.setupCounter -= 1;
+export const createHooksState = (): HooksState => ({
+  insideInteraction: false,
+  errors: [],
+});
 
-    logger.debug(
-      `hooks state counter is ${hooksState.setupCounter} after receiving "${body?.action}" action`,
+const runHook = async (
+  name: 'beforeEach' | 'afterEach',
+  hook: Hook,
+  hooksState: HooksState,
+): Promise<void> => {
+  logger.debug(`executing '${name}' hook`);
+  try {
+    await hook();
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error(String(e));
+    logger.error(`error executing '${name}' hook: ${error.message}`);
+    logger.debug(`Stack trace was: ${error.stack}`);
+    hooksState.errors.push(
+      new Error(`error executing '${name}' hook: ${error.message}`),
     );
+  }
+};
 
+export const registerHooks =
+  (
+    hooks: { beforeEach?: Hook; afterEach?: Hook },
+    hooksState: HooksState,
+  ): RequestHandler =>
+  async ({ body }, _res, next) => {
+    const action = body?.action;
+
+    if (action === 'setup' && !hooksState.insideInteraction) {
+      // rising edge: the first "setup" of a new interaction
+      hooksState.insideInteraction = true;
+      if (hooks.beforeEach)
+        await runHook('beforeEach', hooks.beforeEach, hooksState);
+    } else if (action === 'teardown' && hooksState.insideInteraction) {
+      // falling edge: the first "teardown" after the interaction ran
+      hooksState.insideInteraction = false;
+      if (hooks.afterEach)
+        await runHook('afterEach', hooks.afterEach, hooksState);
+    }
+
+    // Always continue with a successful response. A hook failure must never
+    // become a non-2xx state-change response, or the core will retry it and
+    // desync interaction tracking. Failures are surfaced by the verifier later.
     next();
-  };
-
-export const registerBeforeHook =
-  (beforeEach: Hook, hooksState: HooksState): RequestHandler =>
-  async ({ body }, _res, next) => {
-    if (body?.action === 'setup' && hooksState.setupCounter === 1) {
-      logger.debug("executing 'beforeEach' hook");
-      try {
-        await beforeEach();
-        next();
-      } catch (e) {
-        const error = e instanceof Error ? e : new Error(String(e));
-        logger.error(`error executing 'beforeEach' hook: ${error.message}`);
-        logger.debug(`Stack trace was: ${error.stack}`);
-        next(new Error(`error executing 'beforeEach' hook: ${error.message}`));
-      }
-    } else {
-      next();
-    }
-  };
-
-export const registerAfterHook =
-  (afterEach: Hook, hooksState: HooksState): RequestHandler =>
-  async ({ body }, _res, next) => {
-    if (body?.action === 'teardown' && hooksState.setupCounter === 0) {
-      logger.debug("executing 'afterEach' hook");
-      try {
-        await afterEach();
-        next();
-      } catch (e) {
-        const error = e instanceof Error ? e : new Error(String(e));
-        logger.error(`error executing 'afterEach' hook: ${error.message}`);
-        logger.debug(`Stack trace was: ${error.stack}`);
-        next(new Error(`error executing 'afterEach' hook: ${error.message}`));
-      }
-    } else {
-      next();
-    }
   };

--- a/src/dsl/verifier/proxy/index.ts
+++ b/src/dsl/verifier/proxy/index.ts
@@ -1,1 +1,2 @@
+export * from './hooks';
 export * from './proxy';

--- a/src/dsl/verifier/proxy/proxy.ts
+++ b/src/dsl/verifier/proxy/proxy.ts
@@ -3,12 +3,7 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import HttpProxy from 'http-proxy';
 import logger from '../../../common/logger';
-import {
-  type HooksState,
-  registerAfterHook,
-  registerBeforeHook,
-  registerHookStateTracking,
-} from './hooks';
+import { type HooksState, registerHooks } from './hooks';
 import { createProxyMessageHandler } from './messages';
 import { toServerOptions } from './proxyRequest';
 import { createProxyStateHandler } from './stateHandler/stateHandler';
@@ -29,6 +24,7 @@ export const createProxy = (
   config: ProxyOptions,
   stateSetupPath: string,
   messageTransportPath: string,
+  hooksState: HooksState,
 ): http.Server => {
   const app = express();
   const proxy = new HttpProxy();
@@ -48,18 +44,18 @@ export const createProxy = (
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use('/{*splat}', bodyParser.raw({ type: '*/*' }));
 
-  // Hooks
-  const hooksState: HooksState = {
-    setupCounter: 0,
-  };
-  app.use(stateSetupPath, registerHookStateTracking(hooksState));
-  if (config.beforeEach) {
-    logger.trace("registered 'beforeEach' hook");
-    app.use(stateSetupPath, registerBeforeHook(config.beforeEach, hooksState));
-  }
-  if (config.afterEach) {
-    logger.trace("registered 'afterEach' hook");
-    app.use(stateSetupPath, registerAfterHook(config.afterEach, hooksState));
+  // Hooks. Tracking is only needed when a hook is registered; both hooks share
+  // the same interaction-boundary tracking, so they are registered together.
+  if (config.beforeEach || config.afterEach) {
+    if (config.beforeEach) logger.trace("registered 'beforeEach' hook");
+    if (config.afterEach) logger.trace("registered 'afterEach' hook");
+    app.use(
+      stateSetupPath,
+      registerHooks(
+        { beforeEach: config.beforeEach, afterEach: config.afterEach },
+        hooksState,
+      ),
+    );
   }
 
   // Trace req/res logging

--- a/src/dsl/verifier/verifier.spec.ts
+++ b/src/dsl/verifier/verifier.spec.ts
@@ -9,6 +9,7 @@ import { Verifier } from './verifier';
 const mockState = vi.hoisted(() => ({ executed: false }));
 
 vi.mock('./proxy', () => ({
+  createHooksState: () => ({ insideInteraction: false, errors: [] }),
   createProxy: () =>
     ({
       close: () => {

--- a/src/dsl/verifier/verifier.ts
+++ b/src/dsl/verifier/verifier.ts
@@ -13,7 +13,7 @@ import { isEmpty, omit } from 'lodash';
 import logger, { setLogLevel } from '../../common/logger';
 import { localAddresses } from '../../common/net';
 import ConfigurationError from '../../errors/configurationError';
-import { createProxy, waitForServerReady } from './proxy';
+import { createHooksState, createProxy, waitForServerReady } from './proxy';
 import type { VerifierOptions } from './types';
 
 export class Verifier {
@@ -89,11 +89,15 @@ export class Verifier {
       );
     }
 
-    // Start the verification CLI proxy server
+    // Start the verification CLI proxy server. The hooks state is owned here so
+    // that any beforeEach/afterEach failures recorded during verification can be
+    // surfaced once it completes.
+    const hooksState = createHooksState();
     const server = createProxy(
       this.config,
       this.stateSetupPath,
       this.messageTransportPath,
+      hooksState,
     );
     logger.trace(`proxy created, waiting for startup`);
 
@@ -109,6 +113,13 @@ export class Verifier {
       .then((result) => {
         logger.trace('Verification completed, closing server');
         server.close();
+        if (hooksState.errors.length > 0) {
+          throw new Error(
+            `Provider verification hooks failed:\n${hooksState.errors
+              .map((e) => `  - ${e.message}`)
+              .join('\n')}`,
+          );
+        }
         return result;
       })
       .catch((e) => {


### PR DESCRIPTION
## Summary

Fixes the provider-verification `beforeEach`/`afterEach` hooks so they run **once per interaction** and can no longer be silently disabled by a single hook failure.

Closes #1864.

## Problem

The hooks piggyback on the provider-state setup/teardown requests the core sends to `/_pactSetup`, tracked with a single global counter that fires the hooks only on exact equality (`setupCounter === 1` / `=== 0`). This assumes setup/teardown requests stay perfectly balanced for the whole run — they don't:

1. A throwing hook returned a non-2xx `/_pactSetup` response via `next(err)`.
2. The native core **retries** the failed state-change request.
3. The retry re-incremented the counter **without re-running the hook**, permanently offsetting it — the counter then oscillated **1↔2 instead of 0↔1**.
4. From that point `beforeEach` (needs `=== 1`) and `afterEach` (needs `=== 0`) **never fired again**, yet the run still reported **success**.

So one transient hook failure silently skips provider-state setup for every later interaction while the build stays green.

## Reproduction

Minimal repo (pact 16.0.4 / pact-core 17.1.0, FFI 0.4.28): https://github.com/frudisch/pact-beforeeach-desync-repro

3-interaction pact, `beforeEach` throws once on interaction 1:

| | `beforeEach` | `afterEach` | interactions verified | result |
|---|---|---|---|---|
| **before** | 1 (expected 3) | 0 (expected 3) | 3/3 | ✅ passes (silently wrong) |
| **after**  | 3 | 3 | 3/3 | ❌ fails with a clear hook error |
| control (no throw) | 3 | 3 | 3/3 | ✅ passes |

## Fix

- **Edge-based interaction tracking.** Replace the accumulating `setupCounter` with an `insideInteraction` flag that flips on the setup↔teardown boundaries. It is idempotent under retries (a duplicate `setup` while already inside an interaction is a no-op) and cannot latch into a broken state.
- **Decouple hook failures from the state-change response.** A hook that throws no longer produces a non-2xx response (which the core retries). Errors are recorded on the hooks state and surfaced by the verifier once verification completes — so a failing hook still fails the build, with a clear aggregated message, but never desyncs tracking.

## Notes

- `afterEach` now fires on the first teardown of an interaction rather than the last. This is not a behavioural regression: even today `afterEach` runs before the final teardown's state handler completes (middleware ordering), and the interaction's request has already finished before any teardown.
- Relies on the core sending teardown requests (pact-js-core sets `teardown=true`), which is already the case.

## Tests

- Rewrote `hooks.spec.ts` for the new API, adding regression coverage: a throwing `beforeEach` no longer disables hooks for later interactions; a retried `setup` doesn't re-fire or desync; multi-state interactions fire once.
- Full suite green (283 tests).
- Validated end-to-end against the real core (pact 16.0.4 / pact-core 17.1.0) using the repro above.
