### PR TITLE
feat(verifier): support mTLS client certificates

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -71,6 +71,7 @@ new Verifier(opts).verifyProvider().then(function () {
 | `providerStatesSetupUrl`    | false     | string                                                                                | Deprecated (use URL to send PUT requests to setup a given provider state                                                                                                                           |
 | `stateHandlers`             | false     | object                                                                                | Map of "state" to a function that sets up a given provider state. See docs below for more information                                                                                              |
 | `requestFilter`             | false     | function ([Express middleware](https://expressjs.com/en/guide/using-middleware.html)) | Function that may be used to alter the incoming request or outgoing response from the verification process. See below for use.                                                                     |
+| `tlsClientOptions`          | false     | object                                                                                | TLS client credentials sent by the verification proxy to an HTTPS provider. Supports `pfx` and `passphrase`, or `cert` and `key`.                                                                  |
 | `beforeEach`                | false     | function                                                                              | Function to execute prior to each interaction being validated                                                                                                                                      |
 | `afterEach`                 | false     | function                                                                              | Function to execute after each interaction has been validated                                                                                                                                      |
 | `pactBrokerUsername`        | false     | string                                                                                | Username for Pact Broker basic authentication                                                                                                                                                      |
@@ -113,6 +114,24 @@ const opts = {
 ```
 
 If your broker has a self signed certificate, set the environment variable `SSL_CERT_FILE` (or `SSL_CERT_DIR`) pointing to a copy of your certificate.
+
+To verify a provider that requires mutual TLS, pass the client credentials to
+the verification proxy. PKCS#12 and PEM credentials are supported through the
+standard Node.js TLS options:
+
+```js
+const fs = require('node:fs');
+
+const opts = {
+  providerBaseUrl: 'https://provider.example.com',
+  tlsClientOptions: {
+    pfx: fs.readFileSync('./client.p12'),
+    passphrase: process.env.CLIENT_CERTIFICATE_PASSPHRASE,
+  },
+};
+
+return new Verifier(opts).verifyProvider();
+```
 
 Read more about [Verifying Pacts](https://docs.pact.io/getting_started/verifying_pacts).
 

--- a/src/dsl/verifier/proxy/proxyRequest.spec.ts
+++ b/src/dsl/verifier/proxy/proxyRequest.spec.ts
@@ -50,6 +50,37 @@ describe('#toServerOptions', () => {
 
       expect(res.target).toBe('http://127.0.0.1/');
     });
+
+    it('adds PKCS#12 client credentials to the target', () => {
+      const pfx = Buffer.from('certificate');
+
+      const res = toServerOptions({
+        providerBaseUrl: 'https://test.com',
+        tlsClientOptions: { pfx, passphrase: 'secret' },
+      });
+
+      expect(res.target).toMatchObject({
+        protocol: 'https:',
+        host: 'test.com',
+        pfx,
+        passphrase: 'secret',
+      });
+    });
+
+    it('adds PEM client credentials to the target', () => {
+      const res = toServerOptions({
+        providerBaseUrl: 'https://test.com',
+        tlsClientOptions: {
+          cert: 'client certificate',
+          key: 'client key',
+        },
+      });
+
+      expect(res.target).toMatchObject({
+        cert: 'client certificate',
+        key: 'client key',
+      });
+    });
   });
 
   describe('agent', () => {

--- a/src/dsl/verifier/proxy/proxyRequest.ts
+++ b/src/dsl/verifier/proxy/proxyRequest.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { Readable } from 'node:stream';
+import { parse } from 'node:url';
 import type { ServerOptions } from 'http-proxy';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { parseBody } from './parseBody';
@@ -9,6 +10,16 @@ import type { ProxyOptions } from './types';
 // if there are no targets to proxy (e.g. in the case
 // of message pact
 const defaultBaseURL = () => 'http://127.0.0.1/';
+
+const toProxyTarget = (config: ProxyOptions): ServerOptions['target'] => {
+  const target = config.providerBaseUrl || defaultBaseURL();
+
+  if (!config.tlsClientOptions) {
+    return target;
+  }
+
+  return Object.assign(parse(target), config.tlsClientOptions);
+};
 
 export const toServerOptions = (
   config: ProxyOptions,
@@ -20,7 +31,7 @@ export const toServerOptions = (
   return {
     changeOrigin: config.changeOrigin === true,
     secure: config.validateSSL === true,
-    target: config.providerBaseUrl || defaultBaseURL(),
+    target: toProxyTarget(config),
     agent: systemProxy && new HttpsProxyAgent(systemProxy),
     buffer: Readable.from(parseBody(req)),
   };

--- a/src/dsl/verifier/proxy/types.ts
+++ b/src/dsl/verifier/proxy/types.ts
@@ -1,4 +1,5 @@
 import type express from 'express';
+import type { SecureContextOptions } from 'node:tls';
 import type { AnyJson, JsonMap } from '../../../common/jsonTypes';
 import type { MessageProviders } from '../../message';
 import type { LogLevel } from '../../options';
@@ -51,6 +52,10 @@ export interface ProxyOptions {
   beforeEach?: Hook;
   afterEach?: Hook;
   validateSSL?: boolean;
+  tlsClientOptions?: Pick<
+    SecureContextOptions,
+    'cert' | 'key' | 'passphrase' | 'pfx'
+  >;
   changeOrigin?: boolean;
   providerBaseUrl?: string;
   proxyHost?: string;

--- a/src/dsl/verifier/verifier.spec.ts
+++ b/src/dsl/verifier/verifier.spec.ts
@@ -21,7 +21,7 @@ vi.mock('./proxy', () => ({
         address: 'mock.server.example.com',
       }),
     }) as unknown as Server,
-  waitForServerReady: () => Promise.resolve(),
+  waitForServerReady: (server: Server) => Promise.resolve(server),
 }));
 
 describe('Verifier', () => {
@@ -138,6 +138,25 @@ describe('Verifier', () => {
           await expect(res).rejects.toThrow();
           expect(mockState.executed).toBe(true);
         });
+      });
+
+      it('does not pass TLS client credentials to pact-core', async () => {
+        const verifyPacts = vi
+          .spyOn(serviceFactory, 'verifyPacts')
+          .mockResolvedValue('done');
+        v = new Verifier({
+          ...opts,
+          tlsClientOptions: {
+            pfx: Buffer.from('certificate'),
+            passphrase: 'secret',
+          },
+        });
+
+        await v.verifyProvider();
+
+        expect(verifyPacts).toHaveBeenCalledWith(
+          expect.not.objectContaining({ tlsClientOptions: expect.anything() }),
+        );
       });
     });
   });

--- a/src/dsl/verifier/verifier.ts
+++ b/src/dsl/verifier/verifier.ts
@@ -135,7 +135,7 @@ export class Verifier {
       const { port } = server.address() as AddressInfo;
       const opts: PactCoreVerifierOptions = {
         providerStatesSetupUrl: `${this.address}:${port}${this.stateSetupPath}`,
-        ...omit(this.config, 'handlers'),
+        ...omit(this.config, 'handlers', 'tlsClientOptions'),
         providerBaseUrl: `${this.address}:${port}`,
         transports: (this.config.transports || []).concat([
           {


### PR DESCRIPTION
Closes #1509.

## Summary

- add `tlsClientOptions` to verifier configuration using standard Node.js TLS fields
- pass PKCS#12 or PEM client credentials to the outbound HTTPS proxy target
- keep certificate data and passphrases out of the pact-core verifier options and trace output
- document the mTLS verifier setup

## Verification

- `npm run check`
- `npm test -- --coverage.enabled=false` (286 tests)
- `npm run dist`