### PR TITLE
feat(matchers): add V2 convenience matchers to V3

### DIFF
--- a/src/common/matcherFormats.ts
+++ b/src/common/matcherFormats.ts
@@ -1,0 +1,26 @@
+// These expressions are formatted for the Pact matching engines, so they may
+// not behave exactly like JavaScript regular expressions.
+export const EMAIL_FORMAT = '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$';
+export const ISO8601_DATE_FORMAT =
+  '^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$';
+export const ISO8601_DATETIME_FORMAT =
+  '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$';
+export const ISO8601_DATETIME_WITH_MILLIS_FORMAT =
+  '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d(:?[0-5]\\d)?|Z)$';
+export const ISO8601_TIME_FORMAT =
+  '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$';
+export const RFC1123_TIMESTAMP_FORMAT =
+  '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$';
+export const UUID_V4_FORMAT = '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$';
+export const IPV4_FORMAT = '^(\\d{1,3}\\.)+\\d{1,3}$';
+export const IPV6_FORMAT =
+  '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$';
+export const HEX_FORMAT = '^[0-9a-fA-F]+$';
+
+/**
+ * Validate an example against a Pact regular expression.
+ */
+export function validateExample(example: string, matcher: string): boolean {
+  // Escaped backslashes are sent over the wire as JSON.
+  return new RegExp(matcher.replace('\\\\', '\\')).test(example);
+}

--- a/src/dsl/matchers.ts
+++ b/src/dsl/matchers.ts
@@ -7,26 +7,34 @@
 import { isEmpty, isFunction, isNil, isUndefined } from 'lodash';
 import { times } from 'ramda';
 import type { AnyJson, JsonMap } from '../common/jsonTypes';
+import {
+  EMAIL_FORMAT,
+  HEX_FORMAT,
+  IPV4_FORMAT,
+  IPV6_FORMAT,
+  ISO8601_DATE_FORMAT,
+  ISO8601_DATETIME_FORMAT,
+  ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+  ISO8601_TIME_FORMAT,
+  RFC1123_TIMESTAMP_FORMAT,
+  UUID_V4_FORMAT,
+  validateExample,
+} from '../common/matcherFormats';
 import MatcherError from '../errors/matcherError';
 
-// Note: The following regexes are Ruby formatted,
-// so attempting to parse as JS without modification is probably not going to work as intended!
-export const EMAIL_FORMAT = '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$';
-export const ISO8601_DATE_FORMAT =
-  '^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$';
-export const ISO8601_DATETIME_FORMAT =
-  '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$';
-export const ISO8601_DATETIME_WITH_MILLIS_FORMAT =
-  '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d(:?[0-5]\\d)?|Z)$';
-export const ISO8601_TIME_FORMAT =
-  '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$';
-export const RFC1123_TIMESTAMP_FORMAT =
-  '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$';
-export const UUID_V4_FORMAT = '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$';
-export const IPV4_FORMAT = '^(\\d{1,3}\\.)+\\d{1,3}$';
-export const IPV6_FORMAT =
-  '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$';
-export const HEX_FORMAT = '^[0-9a-fA-F]+$';
+export {
+  EMAIL_FORMAT,
+  HEX_FORMAT,
+  IPV4_FORMAT,
+  IPV6_FORMAT,
+  ISO8601_DATE_FORMAT,
+  ISO8601_DATETIME_FORMAT,
+  ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+  ISO8601_TIME_FORMAT,
+  RFC1123_TIMESTAMP_FORMAT,
+  UUID_V4_FORMAT,
+  validateExample,
+} from '../common/matcherFormats';
 
 export interface MatcherV2<T> {
   value?: T;
@@ -57,17 +65,6 @@ interface TemplateMap {
   [key: string]: AnyTemplate;
 }
 type ArrayTemplate = Array<AnyTemplate>;
-
-/**
- * Validates the given example against the regex.
- *
- * @param example Example to use in the matcher.
- * @param matcher Regular expression to check.
- */
-export function validateExample(example: string, matcher: string): boolean {
-  // Note we escape the double \\ as these get sent over the wire as JSON
-  return new RegExp(matcher.replace('\\\\', '\\')).test(example);
-}
 
 /**
  * The eachLike matcher

--- a/src/v3/matchers.spec.ts
+++ b/src/v3/matchers.spec.ts
@@ -1,4 +1,15 @@
 import * as MatchersV3 from './matchers';
+import {
+  EMAIL_FORMAT,
+  HEX_FORMAT,
+  IPV4_FORMAT,
+  IPV6_FORMAT,
+  ISO8601_DATE_FORMAT,
+  ISO8601_DATETIME_FORMAT,
+  ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+  ISO8601_TIME_FORMAT,
+  RFC1123_TIMESTAMP_FORMAT,
+} from '../dsl/matchers';
 
 describe('V3 Matchers', () => {
   it('compiles with nested examples from issue 1054', () => {
@@ -396,6 +407,101 @@ describe('V3 Matchers', () => {
       });
     });
   });
+
+  const v2CompatibilityMatchers = [
+    {
+      name: 'email',
+      matcher: MatchersV3.email,
+      example: 'hello@world.com',
+      defaultExample: 'hello@pact.io',
+      pattern: EMAIL_FORMAT,
+    },
+    {
+      name: 'ipv4Address',
+      matcher: MatchersV3.ipv4Address,
+      example: '127.0.0.1',
+      defaultExample: '127.0.0.13',
+      pattern: IPV4_FORMAT,
+    },
+    {
+      name: 'ipv6Address',
+      matcher: MatchersV3.ipv6Address,
+      example: '::1',
+      defaultExample: '::ffff:192.0.2.128',
+      pattern: IPV6_FORMAT,
+    },
+    {
+      name: 'iso8601DateTime',
+      matcher: MatchersV3.iso8601DateTime,
+      example: '2015-08-06T16:53:10+01:00',
+      defaultExample: '2015-08-06T16:53:10+01:00',
+      pattern: ISO8601_DATETIME_FORMAT,
+    },
+    {
+      name: 'iso8601DateTimeWithMillis',
+      matcher: MatchersV3.iso8601DateTimeWithMillis,
+      example: '2015-08-06T16:53:10.123+01:00',
+      defaultExample: '2015-08-06T16:53:10.123+01:00',
+      pattern: ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+    },
+    {
+      name: 'iso8601Date',
+      matcher: MatchersV3.iso8601Date,
+      example: '2017-12-05',
+      defaultExample: '2013-02-01',
+      pattern: ISO8601_DATE_FORMAT,
+    },
+    {
+      name: 'iso8601Time',
+      matcher: MatchersV3.iso8601Time,
+      example: 'T22:44:30.652Z',
+      defaultExample: 'T22:44:30.652Z',
+      pattern: ISO8601_TIME_FORMAT,
+    },
+    {
+      name: 'rfc1123Timestamp',
+      matcher: MatchersV3.rfc1123Timestamp,
+      example: 'Mon, 31 Oct 2016 15:21:41 -0400',
+      defaultExample: 'Mon, 31 Oct 2016 15:21:41 -0400',
+      pattern: RFC1123_TIMESTAMP_FORMAT,
+    },
+    {
+      name: 'hexadecimal',
+      matcher: MatchersV3.hexadecimal,
+      example: '6F',
+      defaultExample: '3F',
+      pattern: HEX_FORMAT,
+    },
+  ];
+
+  for (const {
+    name,
+    matcher,
+    example,
+    defaultExample,
+    pattern,
+  } of v2CompatibilityMatchers) {
+    describe(`#${name}`, () => {
+      it('returns the V2-compatible regular expression matcher', () => {
+        expect(matcher(example)).toEqual({
+          'pact:matcher:type': 'regex',
+          regex: pattern,
+          value: example,
+        });
+        expect(matcher()).toEqual({
+          'pact:matcher:type': 'regex',
+          regex: pattern,
+          value: defaultExample,
+        });
+      });
+
+      it('rejects an invalid example', () => {
+        expect(() => matcher('not-valid')).toThrow(
+          `Example 'not-valid' does not match regular expression '${pattern}'`,
+        );
+      });
+    });
+  }
 
   describe('#equal', () => {
     it('returns a JSON representation of an equality matcher', () => {

--- a/src/v3/matchers.ts
+++ b/src/v3/matchers.ts
@@ -1,6 +1,18 @@
 import { isNil, pickBy, times } from 'ramda';
 import RandExp from 'randexp';
 import type { AnyJson, JsonMap } from '../common/jsonTypes';
+import {
+  EMAIL_FORMAT,
+  HEX_FORMAT,
+  IPV4_FORMAT,
+  IPV6_FORMAT,
+  ISO8601_DATE_FORMAT,
+  ISO8601_DATETIME_FORMAT,
+  ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+  ISO8601_TIME_FORMAT,
+  RFC1123_TIMESTAMP_FORMAT,
+  validateExample,
+} from '../common/matcherFormats';
 import type {
   ArrayContainsMatcher,
   DateTimeMatcher,
@@ -15,6 +27,7 @@ import type {
 } from './types';
 
 export * from './types';
+export * from '../common/matcherFormats';
 
 export function isMatcher(x: unknown): x is Matcher<unknown> {
   return (
@@ -329,6 +342,64 @@ export function regex(pattern: RegExp | string, str: string): V3RegexMatcher {
     value: str,
   };
 }
+
+const validatedRegex = (
+  pattern: string,
+  defaultExample: string,
+  example?: string,
+): V3RegexMatcher => {
+  const value = example || defaultExample;
+  if (!validateExample(value, pattern)) {
+    throw new Error(
+      `Example '${value}' does not match regular expression '${pattern}'`,
+    );
+  }
+  return regex(pattern, value);
+};
+
+/** Match an email address using the V2-compatible expression. */
+export const email = (address?: string): V3RegexMatcher =>
+  validatedRegex(EMAIL_FORMAT, 'hello@pact.io', address);
+
+/** Match an IPv4 address using the V2-compatible expression. */
+export const ipv4Address = (ip?: string): V3RegexMatcher =>
+  validatedRegex(IPV4_FORMAT, '127.0.0.13', ip);
+
+/** Match an IPv6 address using the V2-compatible expression. */
+export const ipv6Address = (ip?: string): V3RegexMatcher =>
+  validatedRegex(IPV6_FORMAT, '::ffff:192.0.2.128', ip);
+
+/** Match an ISO 8601 date and time using the V2-compatible expression. */
+export const iso8601DateTime = (value?: string): V3RegexMatcher =>
+  validatedRegex(ISO8601_DATETIME_FORMAT, '2015-08-06T16:53:10+01:00', value);
+
+/** Match an ISO 8601 date and time with fractional-second precision. */
+export const iso8601DateTimeWithMillis = (value?: string): V3RegexMatcher =>
+  validatedRegex(
+    ISO8601_DATETIME_WITH_MILLIS_FORMAT,
+    '2015-08-06T16:53:10.123+01:00',
+    value,
+  );
+
+/** Match an ISO 8601 date using the V2-compatible expression. */
+export const iso8601Date = (value?: string): V3RegexMatcher =>
+  validatedRegex(ISO8601_DATE_FORMAT, '2013-02-01', value);
+
+/** Match an ISO 8601 time using the V2-compatible expression. */
+export const iso8601Time = (value?: string): V3RegexMatcher =>
+  validatedRegex(ISO8601_TIME_FORMAT, 'T22:44:30.652Z', value);
+
+/** Match an RFC 1123 timestamp using the V2-compatible expression. */
+export const rfc1123Timestamp = (value?: string): V3RegexMatcher =>
+  validatedRegex(
+    RFC1123_TIMESTAMP_FORMAT,
+    'Mon, 31 Oct 2016 15:21:41 -0400',
+    value,
+  );
+
+/** Match a hexadecimal string using the V2-compatible expression. */
+export const hexadecimal = (value?: string): V3RegexMatcher =>
+  validatedRegex(HEX_FORMAT, '3F', value);
 
 /**
  * Matches the content type of a multipart field.


### PR DESCRIPTION
### Summary

V3 users currently lose several convenience matchers when migrating from V2, even though V3 already supports the same regular-expression matcher representation.

This change:

- adds `email`, `ipv4Address`, `ipv6Address`, `iso8601DateTime`, `iso8601DateTimeWithMillis`, `iso8601Date`, `iso8601Time`, `rfc1123Timestamp`, and `hexadecimal` to `MatchersV3`
- preserves the V2 expressions, defaults, and invalid-example validation through a dependency-free shared format module
- keeps the existing V2 exports and behavior unchanged
- adds table-driven coverage for custom examples, default examples, and invalid examples across all nine matchers

The V3 additions return native `V3RegexMatcher` values, so this is additive and does not introduce legacy matcher shapes into the V3 API.

Fixes #1218.

Credit to @mefellows for identifying the V2/V3 parity gap and calling out email as a concrete example.

### Validation

- `./node_modules/.bin/vitest run src/v3/matchers.spec.ts src/dsl/matchers.spec.ts --coverage.enabled=false` (134 tests passed)
- `./node_modules/.bin/vitest run` (301 tests passed; coverage thresholds passed)
- `./node_modules/.bin/biome format`
- `./node_modules/.bin/biome lint`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc`
- `./node_modules/.bin/copyfiles package.json ./dist`

`npm run dist` was not run as a wrapper because the npm CLI was unavailable locally; its formatting, lint, test, TypeScript build, and package-copy steps were run directly as listed above.