### PR TITLE
fix(verifier): accept lifecycle state handlers

### DIFF
--- a/src/dsl/verifier/proxy/stateHandler/setupStates.ts
+++ b/src/dsl/verifier/proxy/stateHandler/setupStates.ts
@@ -1,4 +1,3 @@
-import type { JsonMap } from '../../../../common/jsonTypes';
 import logger from '../../../../common/logger';
 import type {
   ProviderState,
@@ -22,7 +21,7 @@ const transformStateFunc = (fn: StateHandler): StateFuncWithSetup =>
 export const setupStates = (
   state: ProviderState,
   config: ProxyOptions,
-): Promise<JsonMap | undefined> => {
+): ReturnType<StateFunc> => {
   logger.debug(`setting up state '${JSON.stringify(state)}'`);
 
   const handler = config.stateHandlers

--- a/src/dsl/verifier/proxy/types.ts
+++ b/src/dsl/verifier/proxy/types.ts
@@ -30,7 +30,8 @@ export type StateAction = 'setup' | 'teardown';
  * Respond to the state setup event, optionally returning a map of provider
  * values to dynamically inject into the incoming request to test
  */
-export type StateFunc = (parameters?: AnyJson) => Promise<JsonMap | undefined>;
+// biome-ignore lint/suspicious/noConfusingVoidType: state handlers may intentionally resolve without a value.
+export type StateFunc = (parameters?: AnyJson) => Promise<JsonMap | void>;
 
 /**
  * Respond to the state setup event, with the ability to hook into the setup/teardown

--- a/src/dsl/verifier/types.ts
+++ b/src/dsl/verifier/types.ts
@@ -1,5 +1,4 @@
 import type { VerifierOptions as PactCoreVerifierOptions } from '@pact-foundation/pact-core';
-import type { MessageProviderOptions } from '../options';
 
 import type { ProxyOptions } from './proxy/types';
 
@@ -14,5 +13,4 @@ export type PactNodeVerificationExcludedOptions = Pick<
 >;
 
 export type VerifierOptions = PactNodeVerificationExcludedOptions &
-  ProxyOptions &
-  Partial<MessageProviderOptions>;
+  ProxyOptions;

--- a/src/dsl/verifier/verifier.spec.ts
+++ b/src/dsl/verifier/verifier.spec.ts
@@ -55,6 +55,22 @@ describe('Verifier', () => {
         expect(v).toHaveProperty('config.stateHandlers');
         expect(v).toHaveProperty('config.requestFilter');
       });
+
+      it('accepts state handlers with separate setup and teardown functions', () => {
+        const stateHandler = {
+          setup: vi.fn(async () => {}),
+          teardown: vi.fn(async () => {}),
+        };
+
+        v = new Verifier({
+          providerBaseUrl,
+          stateHandlers: {
+            [state]: stateHandler,
+          },
+        });
+
+        expect(v).toHaveProperty(`config.stateHandlers.${state}`, stateHandler);
+      });
     });
   });
 


### PR DESCRIPTION
### What this changes

`VerifierOptions` currently intersects `ProxyOptions` with `Partial<MessageProviderOptions>`. Both types declare `stateHandlers` with different call signatures, so TypeScript requires every verifier state handler to satisfy both the HTTP and message-provider forms. That rejects the supported `{ setup, teardown }` lifecycle form.

This removes the redundant `MessageProviderOptions` intersection because `ProxyOptions` already carries `logLevel`, `messageProviders`, and the HTTP verifier `stateHandlers`. It also lets state handlers resolve without a value, matching their existing optional provider-state injection behaviour, and derives the internal `setupStates` return type from `StateFunc`.

The change is type-compatible and does not alter verifier runtime behaviour. Existing function handlers and handlers returning provider-state values remain supported.

Credit to @ghost91- for the minimal failing example, @valkolovos for tracing the conflict to the overlapping declarations, and @muratkeremozcan for supplying a standalone reproduction.

Fixes #1164

### Verification

- Confirmed the regression test fails on `master` with `TS2418` before the fix.
- `biome format` (228 files)
- `biome lint` (228 files)
- `tsc --noEmit`
- `vitest run` (28 files, 284 tests; coverage thresholds passed)
- Distribution build via `rimraf dist`, `tsc`, and `copyfiles package.json ./dist`
- Regression consumers (14 files, 40 passed, 2 skipped)
- Regression providers (9 files, 11 passed)
- `git diff --check`

No practical local test suite was omitted. The repository CI operating-system and Node.js version matrix remains to run.
