### PR TITLE
Fix/pact ffi 0.5.6

### DIFF
--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -24,19 +24,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -45,29 +46,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1843,11 +1844,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/http/package-lock.json
+++ b/examples/http/package-lock.json
@@ -22,19 +22,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -43,29 +44,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1841,11 +1842,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/matchers/package-lock.json
+++ b/examples/matchers/package-lock.json
@@ -22,19 +22,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -43,29 +44,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1841,11 +1842,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/messages/package-lock.json
+++ b/examples/messages/package-lock.json
@@ -19,19 +19,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -40,29 +41,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1838,11 +1839,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/multipart/package-lock.json
+++ b/examples/multipart/package-lock.json
@@ -25,19 +25,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -46,29 +47,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1844,11 +1845,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/plugins/package-lock.json
+++ b/examples/plugins/package-lock.json
@@ -23,19 +23,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -44,29 +45,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1842,11 +1843,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/provider-state/package-lock.json
+++ b/examples/provider-state/package-lock.json
@@ -22,19 +22,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -43,29 +44,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1841,11 +1842,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/xml/package-lock.json
+++ b/examples/xml/package-lock.json
@@ -23,19 +23,20 @@
     },
     "../..": {
       "name": "@pact-foundation/pact",
-      "version": "16.4.0",
+      "version": "17.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
-        "chalk": "4.1.2",
+        "chalk": "6.0.0",
         "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -44,29 +45,29 @@
         "stack-utils": "^2.0.6"
       },
       "devDependencies": {
-        "@babel/cli": "7.28.6",
-        "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.3",
-        "@biomejs/biome": "2.4.14",
-        "@tsconfig/node20": "20.1.9",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "8.0.2",
+        "@biomejs/biome": "2.4.16",
+        "@tsconfig/node22": "22.0.5",
         "@types/express": "4.17.25",
         "@types/http-proxy": "1.17.17",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/nock": "11.1.0",
-        "@types/node": "24.12.2",
-        "@types/ramda": "0.31.1",
+        "@types/node": "24.13.3",
+        "@types/ramda": "0.32.0",
         "@types/stack-utils": "2.0.3",
-        "@vitest/coverage-v8": "^3.0.0",
-        "commit-and-tag-version": "12.7.1",
+        "@vitest/coverage-v8": "3.2.4",
+        "commit-and-tag-version": "13.1.2",
         "copyfiles": "2.4.1",
-        "nock": "14.0.14",
+        "nock": "14.0.17",
         "rimraf": "6.1.3",
-        "typedoc": "^0.28.19",
+        "typedoc": "0.28.20",
         "typescript": "6.0.3",
-        "vitest": "^3.0.0"
+        "vitest": "3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "../../node_modules/@ampproject/remapping": {
@@ -1842,11 +1843,6 @@
     },
     "../../node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "17.0.1",
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.2.0",
+        "@pact-foundation/pact-core": "^20.1.0",
         "@scarf/scarf": "^1.4.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
@@ -2217,7 +2217,9 @@
       "license": "MIT"
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "19.2.0",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-20.1.0.tgz",
+      "integrity": "sha512-VPMV5X/gq5BTcQH7lbmmj5v4O1p+rG5iHemghrjNz+RFMHjISf657uIL5pZvhkOilHfGH2QuAvMgwRP16g2isw==",
       "cpu": [
         "x64",
         "ia32",
@@ -2238,22 +2240,22 @@
         "underscore": "1.13.8"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "optionalDependencies": {
-        "@pact-foundation/pact-core-darwin-arm64": "19.2.0",
-        "@pact-foundation/pact-core-darwin-x64": "19.2.0",
-        "@pact-foundation/pact-core-linux-arm64-glibc": "19.2.0",
-        "@pact-foundation/pact-core-linux-arm64-musl": "19.2.0",
-        "@pact-foundation/pact-core-linux-x64-glibc": "19.2.0",
-        "@pact-foundation/pact-core-linux-x64-musl": "19.2.0",
-        "@pact-foundation/pact-core-windows-x64": "19.2.0"
+        "@pact-foundation/pact-core-darwin-arm64": "20.1.0",
+        "@pact-foundation/pact-core-darwin-x64": "20.1.0",
+        "@pact-foundation/pact-core-linux-arm64-glibc": "20.1.0",
+        "@pact-foundation/pact-core-linux-arm64-musl": "20.1.0",
+        "@pact-foundation/pact-core-linux-x64-glibc": "20.1.0",
+        "@pact-foundation/pact-core-linux-x64-musl": "20.1.0",
+        "@pact-foundation/pact-core-windows-x64": "20.1.0"
       }
     },
     "node_modules/@pact-foundation/pact-core-darwin-arm64": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-19.2.0.tgz",
-      "integrity": "sha512-cQvvWfJKS7iMzkunzh/kdgmyVLhAxyr/BQ8fOnMco2M/1+GHR+sOXvhrR1tes+NAYd1xjE3fbg1K2Flno8aDBw==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-20.1.0.tgz",
+      "integrity": "sha512-GsQ1vgrcmfGFVzmudvvXthPrd53tarSxrSOBl9TvUJsnhCF/qENYe5hTYWXiAtCpugB3g7V8/J+iOg5qrtPhOw==",
       "cpu": [
         "arm64"
       ],
@@ -2264,9 +2266,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-darwin-x64": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-19.2.0.tgz",
-      "integrity": "sha512-UltPXDZ+h1r3JqgIpEBP16bQzB90otd1QbcoeM3XakF9khCrYhW4y9llSuaosyqPFYwCk+mLaZTl/4iitJJaow==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-20.1.0.tgz",
+      "integrity": "sha512-ZQdwQJtSwNPCeMxIfl8XJPeizohPh7jquS6JBNw20EmSKg5eCVWIw3hdKuxZuIYGt/zze05ky8Z45nzn3qvHiQ==",
       "cpu": [
         "x64"
       ],
@@ -2277,9 +2279,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-glibc": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-19.2.0.tgz",
-      "integrity": "sha512-amiv4COurH1FRa7DSH3ks4UPQCb5J3x4GKrArf8UsTOkNhVGFUWVl83LOELj9Gtk67GwJ96iF7/fQps8I/iFIA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-20.1.0.tgz",
+      "integrity": "sha512-Jy+zd2tEL5jAbOf2PcW/xvf1onJBea7IzuFZMIKs+Jh0dl0c+9M7eg8L13plzGU4T3xhOzMn5X8IXyajYt2iIQ==",
       "cpu": [
         "arm64"
       ],
@@ -2293,9 +2295,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-musl": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-19.2.0.tgz",
-      "integrity": "sha512-tGWF7dP72Ho1A1PApyUqUMRI/e+gfbPxfaXxwWMXNh8JLK2jQQnP4bWymGwHQ4vxL7wn8ayx8I5y6x1vk/2+rA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-20.1.0.tgz",
+      "integrity": "sha512-8yY9ckAj0Fx/wojtsdonf7GEdTEfdvD+yzllZlmwCbfSGqA7dsbThVtSAjt+myylce82YSqxzmgqPJJn5GSm3w==",
       "cpu": [
         "arm64"
       ],
@@ -2309,7 +2311,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-glibc": {
-      "version": "19.2.0",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-20.1.0.tgz",
+      "integrity": "sha512-S4avgkfvM9fe2dtnAVUw8FRRs4Bjj4YMcrDcoGondf58mQtIAnsNuKVrmBjfz29qGTxb4amopTTlQNW6w8VIew==",
       "cpu": [
         "x64"
       ],
@@ -2323,9 +2327,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-musl": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-19.2.0.tgz",
-      "integrity": "sha512-n0m39CzVkq8J2alir1redm0rAdUVQzkKJqYBQdRmhEIa+QeGjUrJq+gmakUysoJxfSY4UthnJ9jS8SoyiZ+k6A==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-20.1.0.tgz",
+      "integrity": "sha512-o7qzQ4C4mBYpBCDmtGssGurCTFI/9vuqP1T8VavyeTbyeZThI9j2iWTpeNOmKlrI5+jnaWHYNeuwpqh6FFRurQ==",
       "cpu": [
         "x64"
       ],
@@ -2339,9 +2343,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-windows-x64": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-19.2.0.tgz",
-      "integrity": "sha512-WZSDBL1Sn8y5+YJTK+HDiS/Fn9th1M4QJW2dflQ8UFwoaIh6yb0TrJjtuWbDGIwNeD4Sv8CJ5jJOf1nyNjFLfg==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-20.1.0.tgz",
+      "integrity": "sha512-EutN/FQy/Fa6y5k0+Kfqy9o6uLzcz9J4y6aq6x+AsBpsPIakBYYugCZzXt6WZ+W9jzgY0cNtwOGjkWZI/gUucA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ]
   },
   "dependencies": {
-    "@pact-foundation/pact-core": "^19.2.0",
+    "@pact-foundation/pact-core": "^20.1.0",
     "@scarf/scarf": "^1.4.0",
     "axios": "^1.12.2",
     "body-parser": "^2.2.0",
@@ -146,5 +146,10 @@
     "onlyBuiltDependencies": [
       "@pact-foundation/pact-core"
     ]
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true,
+    "esbuild": true,
+    "@scarf/scarf": true
   }
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,8 +1,8 @@
-import logger from '@pact-foundation/pact-core/src/logger';
+import logger from '@pact-foundation/pact-core/dist/logger';
 
 import { version } from '../../package.json';
 
-export * from '@pact-foundation/pact-core/src/logger';
+export * from '@pact-foundation/pact-core/dist/logger';
 
 const context = `pact@${version}`;
 


### PR DESCRIPTION
Pulls in latest pact-ffi 0.5.6 by way of pact-js-core 20.1.0

Fixes #1835 
Fixes #1713

Includes https://github.com/pact-foundation/pact-core-mock-server/pull/14