### PR TITLE
chore(ci): remove npmrc / node auth token due to trusted pub

### DIFF
--- a/scripts/ci/lib/publish.sh
+++ b/scripts/ci/lib/publish.sh
@@ -7,9 +7,6 @@ require_binary npm
 "${SCRIPT_DIR}"/prepare-release.sh
 VERSION="$("$SCRIPT_DIR/get-version.sh")"
 
-echo "--> Preparing npmrc file"
-"$SCRIPT_DIR"/create_npmrc_file.sh
-
 echo "--> Releasing version ${VERSION}"
 echo "--> Releasing artifacts"
 echo "    Publishing pact@${VERSION}..."

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the 
 
 require_env_var CI "This script must be run from CI. If you are running locally, note that it stamps your repo git settings."
 require_env_var GITHUB_ACTOR
-require_env_var NODE_AUTH_TOKEN
 
 # Setup git for github actions
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"


### PR DESCRIPTION
ci release failing after #1660 due to env var req that wont be satisfied anymore