### PR TITLE
Revert "fix(deps): update dependency https-proxy-agent to v9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^7.0.6",
         "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
         "ramda": "^0.32.0",
@@ -3535,12 +3535,10 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "version": "7.1.4",
       "license": "MIT",
       "engines": {
-        "node": ">= 20"
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -5297,17 +5295,14 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "version": "7.0.6",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -6285,23 +6280,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
       }
     },
     "node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "graphql": "^16.11.0",
     "graphql-tag": "^2.12.6",
     "http-proxy": "^1.18.1",
-    "https-proxy-agent": "^9.0.0",
+    "https-proxy-agent": "^7.0.6",
     "js-base64": "^3.7.8",
     "lodash": "^4.17.21",
     "ramda": "^0.32.0",


### PR DESCRIPTION
Reverts pact-foundation/pact-js#1861

FIxes #1915 

v8 of https-proxy-agent brings in esm https://github.com/TooTallNate/proxy-agents/releases/tag/https-proxy-agent%408.0.0mm downgrade, to v7